### PR TITLE
search for models in only one path ("{{ env_var('SYNC_NAME') }}/models")

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -4,7 +4,7 @@ config-version: 2
 
 profile: 'default'
 
-model-paths: ["{{ env_var('PARTNER_DATASET_ID') }}/models"]
+model-paths: ["{{ env_var('SYNC_NAME') }}/models"]
 packages-install-path: "{{ env_var('PARTNER_DATASET_ID') }}/dbt-packages"
 
 models:
@@ -20,6 +20,10 @@ models:
       +incremental_strategy: insert_overwrite
       +on_schema_change: sync_all_columns
       +full_refresh: false
+    1_cta_tables:
+      +tags:
+        - cta
+      +materialized: table
     2_partner_matviews:
       +tags: 
         - partner


### PR DESCRIPTION
This change has already been deployed to composer 😎 this PR is just making it official!

Github won't tell you this, but the `dbt_project.yml` we had in prod composer was looking for dbt models in both `PARTNER_DATASET_ID/models` and `SYNC_NAME/models`. But when PARTNER_DATASET_ID is the same as SYNC_NAME, which it will be most of the time, then dbt finds the files twice and throws an error saying the models are duplicated (more specifically, that model reference paths are ambiguous - it's not smart enough to know it's looking at the same path twice 🙄 )