### PR TITLE
feat: migrate dbt for FB Marketing syncs

### DIFF
--- a/facebook_marketing/models/0_ctes/ad_account_ab2.sql
+++ b/facebook_marketing/models/0_ctes/ad_account_ab2.sql
@@ -10,7 +10,7 @@ select
     cast(age as {{ dbt_utils.type_float() }}) as age,
     cast(name as {{ dbt_utils.type_string() }}) as name,
     cast(owner as {{ dbt_utils.type_float() }}) as owner,
-    cast(tax_id as {{ dbt_utils.type_float() }}) as tax_id,
+    cast(tax_id as {{ dbt_utils.type_string() }}) as tax_id,
     cast(balance as {{ dbt_utils.type_string() }}) as balance,
     cast(partner as {{ dbt_utils.type_float() }}) as partner,
     cast(rf_spec as {{ type_json() }}) as rf_spec,


### PR DESCRIPTION
This is already running successfully in Prod Composer. Only change from V1 world is that `tax_id` needs to be cast as a string instead of a float... but does anyone really use that field anyway?