### PR TITLE
feat: run dbt dev deploy only when a PR has been reviewed and approved

### DIFF
--- a/.github/workflows/deploy_dbt_models_dev.yaml
+++ b/.github/workflows/deploy_dbt_models_dev.yaml
@@ -1,20 +1,19 @@
 name: Deploy dbt Models (DEV)
 
-# Run only on pushes to main
-on:
-  pull_request:
-    types: [labeled, opened, synchronize, reopened]
-
 # Pull secrets from repo and assign to env vars
 env:
   GOOGLE_PROJECT_ID_DEV: ${{ secrets.GOOGLE_PROJECT_ID_DEV }}
   GOOGLE_COMPOSER_ENVIRONMENT_DEV: ${{ secrets.GOOGLE_COMPOSER_ENVIRONMENT_DEV }}
   GOOGLE_SERVICE_ACCOUNT_DEV: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_DEV }}
 
+# Run only when a PR has been reviewed and approved
+on:
+  pull_request_review:
+    types: [submitted]
+
 jobs:
-  deploy_dev:
-    # Only run if PR has the 'dev_deploy' label 
-    if: ${{ contains(github.event.pull_request.labels.*.name,'dev_deploy') }}
+  PR_approved:
+    if: github.event.review.state == 'approved'
     name: Deploy dbt Models (DEV)
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Made this change to the workflow so that once this repo is public, only users granted explicit access will be able to review PRs (and therefore trigger auto-deployments to our dev environment)

Also changed this config in the repo (which changes nothing now, but will be relevant when public):
<img width="791" alt="image" src="https://user-images.githubusercontent.com/47834372/206464920-1455cb32-eb41-49f7-a298-830c0aefbba6.png">

@jitoquinto @huystuhh I'm inclined to suggest that we do the same thing in `airflow-dags` to avoid confusion, but curious what y'all think about all this 👀 
