### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # all of these users will be requested for
 # review when someone opens a pull request.
-*       @emily-flambe @jitoquinto
+*       @emily-flambe @jitoquinto @michaelefisher


### PR DESCRIPTION
If `airflow-dags` gets to have a CODEOWNERS then this repo should too! Unless @michaelefisher is there a reason we wouldn't include this in a public repo?