### PR TITLE
feat: apply BQ profile config changes (retries) to partner

### DIFF
--- a/dbt-cta/profiles.yml
+++ b/dbt-cta/profiles.yml
@@ -12,7 +12,6 @@ default:
       location: US
       method: oauth
       priority: batch
-      retries: 1
       threads: 4
       type: bigquery
       job_creation_timeout_seconds: 30
@@ -25,7 +24,6 @@ default:
       location: US
       method: oauth
       priority: batch
-      retries: 1
       threads: 4
       type: bigquery
       #job_creation_timeout_seconds: 30


### PR DESCRIPTION
I was being dumb earlier and thought I was commenting out prod. Nope, I was commenting out the `partner` profile. (But only SQL auto-deploys in this repo, so this didn't actually deploy to prod composer... disaster averted)