### PR TITLE
fix: use 'ref' instead of 'source' to specify model dependencies for partner views

### DIFF
--- a/dbt-cta/facebook_marketing/models/3_partner_views/ctam_ads_insights_overall.sql
+++ b/dbt-cta/facebook_marketing/models/3_partner_views/ctam_ads_insights_overall.sql
@@ -1,4 +1,5 @@
--- depends_on: {{ source('partner', 'ads_insights_overall') }}, {{ source('partner', 'ads_insights_platform_and_device') }}, {{ source('partner', 'ads') }}, {{ source('partner', 'ad_creatives') }}, {{ source('partner', 'ad_sets') }}, {{ source('partner', 'ad_account') }}, {{ source('partner', 'campaigns') }}, {{ source('partner', 'account_report') }}, {{ source('partner', 'campaign_report') }}, {{ source('partner', 'ad_set_report') }}
+-- depends_on: {{ ref('ad_account') }}, {{ ref('account_report') }}, {{ ref('ad_creatives') }}, {{ ref('ad_set_report') }}, {{ ref('ad_sets') }}, {{ ref('ads_insights_overall') }}, {{ ref('ads_insights_platform_and_device') }}, {{ ref('ads') }}, {{ ref('campaign_report') }}, {{ ref('campaigns') }}
+
 
 with stats as (
 	select

--- a/dbt-cta/facebook_marketing/models/3_partner_views/ctam_ads_insights_platform_and_device.sql
+++ b/dbt-cta/facebook_marketing/models/3_partner_views/ctam_ads_insights_platform_and_device.sql
@@ -1,4 +1,4 @@
--- depends_on: {{ source('partner', 'ads_insights_overall') }}, {{ source('partner', 'ads_insights_platform_and_device') }}, {{ source('partner', 'ads') }}, {{ source('partner', 'ad_creatives') }}, {{ source('partner', 'ad_sets') }}, {{ source('partner', 'ad_account') }}, {{ source('partner', 'campaigns') }}, {{ source('partner', 'account_report') }}, {{ source('partner', 'campaign_report') }}, {{ source('partner', 'ad_set_report') }}
+-- depends_on: {{ ref('ad_account') }}, {{ ref('account_report') }}, {{ ref('ad_creatives') }}, {{ ref('ad_set_report') }}, {{ ref('ad_sets') }}, {{ ref('ads_insights_overall') }}, {{ ref('ads_insights_platform_and_device') }}, {{ ref('ads') }}, {{ ref('campaign_report') }}, {{ ref('campaigns') }}
 
 with stats as (
 	select

--- a/dbt-cta/snapchat_marketing/models/3_partner_views/snapchat_ctam.sql
+++ b/dbt-cta/snapchat_marketing/models/3_partner_views/snapchat_ctam.sql
@@ -1,4 +1,4 @@
--- depends_on: {{ source('partner', 'ad_stats') }}, {{ source('partner', 'ads') }}, {{ source('partner', 'creatives') }}, {{ source('partner', 'adsquads') }}, {{ source('partner', 'campaigns') }}
+-- depends_on: {{ ref('adaccounts') }}, {{ ref('ad_stats') }}, {{ ref('ads') }}, {{ ref('adsquads_skadnetwork_properties') }}, {{ ref('adsquads_targeting_geos') }}, {{ ref('adsquads_targeting') }}, {{ ref('adsquads') }}, {{ ref('campaigns') }}, {{ ref('creatives_web_view_properties') }}, {{ ref('creatives') }}, {{ ref('media') }}, {{ ref('organizations_configuration_settings') }}, {{ ref('organizations') }}, {{ ref('segments') }}
 
 with stats as (
 	select  


### PR DESCRIPTION
This is a small thing, but:

When running a sync for the first time, the partner dbt step would always fail first and then succeed, because it was waiting for the matviews to exist in order to create the views. This was always a bit mysterious, since the tables were right there in the `--depends_on:` bit at the top, but I THINK that only works with {{ ref('foo') }}, not with {{ source('bar','foo') }}. Seems arbitrary but what do I know.