### PR TITLE
fix: make sure facebook matviews dont break without full refresh macro

### DIFF
--- a/dbt-cta/facebook_marketing/models/1_cta_base/account_report_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_base/account_report_base.sql
@@ -6,20 +6,17 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = '_ad_set_report_hashid'
+    partitions = partitions_to_replace,
+    unique_key = '_account_report_hashid'
 ) }}
 
 -- depends_on: {{ ref('ads_insights_overall_base') }}
-with aggregations as (
 
+with aggregations as (
 select
     date_start,
     account_id,
     account_name,
-    campaign_id,
-    campaign_name,
-    adset_id,
-    adset_name,
     timestamp_trunc(_airbyte_emitted_at, day) as _airbyte_emitted_at,
     sum(clicks) as clicks,
     sum(impressions) as impressions,
@@ -29,10 +26,6 @@ GROUP BY
     date_start,
     account_id,
     account_name,
-    campaign_id,
-    campaign_name,
-    adset_id,
-    adset_name,
     timestamp_trunc(_airbyte_emitted_at, day)
 )
 
@@ -41,12 +34,8 @@ SELECT
     {{ dbt_utils.surrogate_key([
     'date_start',
     'account_id',
-    'account_name',
-    'campaign_id',
-    'campaign_name',
-    'adset_id',
-    'adset_name'
-    ]) }} as _ad_set_report_hashid
+    'account_name'
+    ]) }} as _account_report_hashid
     ,current_timestamp as _airbyte_normalized_at
 FROM aggregations
 

--- a/dbt-cta/facebook_marketing/models/1_cta_base/ad_account_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_base/ad_account_base.sql
@@ -6,6 +6,7 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    partitions = partitions_to_replace,
     unique_key = '_airbyte_ad_account_hashid'
 ) }}
 

--- a/dbt-cta/facebook_marketing/models/1_cta_base/ad_creatives_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_base/ad_creatives_base.sql
@@ -6,6 +6,7 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    partitions = partitions_to_replace,
     unique_key = '_airbyte_ad_creatives_hashid'
 ) }}
 

--- a/dbt-cta/facebook_marketing/models/1_cta_base/ad_sets_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_base/ad_sets_base.sql
@@ -6,36 +6,33 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = '_airbyte_ads_hashid'
+    partitions = partitions_to_replace,
+    unique_key = '_airbyte_ab_id',
+    schema = "dev_fb_marketing_latest_conn"
 ) }}
 
--- depends_on: {{ ref('ads_ab3') }}
+-- depends_on: {{ ref('ad_sets_ab3') }}
 select
-     _airbyte_ads_hashid
+     _airbyte_ad_sets_hashid
     ,_airbyte_emitted_at
     ,_airbyte_ab_id
-    ,JSON_EXTRACT_SCALAR(creative, "$.id") as creative_id
     ,id
     ,name
-    ,status
     ,adlabels
-    ,adset_id
     ,bid_info
-    ,bid_type
-    ,creative
+    ,end_time
     ,targeting
     ,account_id
-    ,bid_amount
+    ,start_time
     ,campaign_id
     ,created_time
-    ,source_ad_id
+    ,daily_budget
     ,updated_time
-    ,tracking_specs
-    ,recommendations
-    ,conversion_specs
+    ,lifetime_budget
+    ,promoted_object
+    ,budget_remaining
     ,effective_status
-    ,last_updated_by_app_id
-from {{ ref('ads_ab3') }}
+from {{ ref('ad_sets_ab3') }}
 
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/facebook_marketing/models/1_cta_base/ads_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_base/ads_base.sql
@@ -6,32 +6,37 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = '_airbyte_ab_id',
-    schema = "dev_fb_marketing_latest_conn"
+    partitions = partitions_to_replace,
+    unique_key = '_airbyte_ads_hashid'
 ) }}
 
--- depends_on: {{ ref('ad_sets_ab3') }}
+-- depends_on: {{ ref('ads_ab3') }}
 select
-     _airbyte_ad_sets_hashid
+     _airbyte_ads_hashid
     ,_airbyte_emitted_at
     ,_airbyte_ab_id
+    ,JSON_EXTRACT_SCALAR(creative, "$.id") as creative_id
     ,id
     ,name
+    ,status
     ,adlabels
+    ,adset_id
     ,bid_info
-    ,end_time
+    ,bid_type
+    ,creative
     ,targeting
     ,account_id
-    ,start_time
+    ,bid_amount
     ,campaign_id
     ,created_time
-    ,daily_budget
+    ,source_ad_id
     ,updated_time
-    ,lifetime_budget
-    ,promoted_object
-    ,budget_remaining
+    ,tracking_specs
+    ,recommendations
+    ,conversion_specs
     ,effective_status
-from {{ ref('ad_sets_ab3') }}
+    ,last_updated_by_app_id
+from {{ ref('ads_ab3') }}
 
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/facebook_marketing/models/1_cta_base/ads_insights_overall_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_base/ads_insights_overall_base.sql
@@ -6,21 +6,18 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = '_airbyte_ads_insights_platform_and_device_hashid'
+    partitions = partitions_to_replace,
+    unique_key = '_airbyte_ads_insights_overall_hashid'
 ) }}
 
--- depends_on: {{ ref('ads_insights_platform_and_device_ab4') }}
+-- depends_on: {{ ref('ads_insights_overall_ab4') }}
 SELECT
-     _airbyte_ads_insights_platform_and_device_hashid
+     _airbyte_ads_insights_overall_hashid
     ,_airbyte_emitted_at
     ,_airbyte_ab_id
     ,ad_id
     ,date_start
     ,date_stop
-    --PLATFORM AND DEVICE
-    ,publisher_platform
-    ,platform_position
-    ,impression_device
     --METRICS
     ,cpc
     ,cpm
@@ -83,13 +80,13 @@ SELECT
     ,estimated_ad_recall_rate_lower_bound
     ,estimated_ad_recall_rate_upper_bound
     ,qualifying_question_qualify_answer_rate
-    --VIDEO METRICS
+    ----VIDEO METRICS
     ,video_played
-    ,video_continuous_2_sec_watched_actions
+    ,video_continuous_2_sec_watched
     ,cost_per_2_sec_continuous_video_view
-    ,video_15_sec_watched_actions
+    ,video_15_sec_watched
     ,cost_per_15_sec_video_view
-    ,video_30_sec_watched_actions
+    ,video_30_sec_watched
     ,cost_per_thruplay
     ,video_p25_watched
     ,video_p50_watched
@@ -100,7 +97,7 @@ SELECT
     ,landing_page_views
     ,shares
     ,conversion_values
-from {{ ref('ads_insights_platform_and_device_ab4') }}
+from {{ ref('ads_insights_overall_ab4') }}
 
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/facebook_marketing/models/1_cta_base/ads_insights_platform_and_device_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_base/ads_insights_platform_and_device_base.sql
@@ -6,17 +6,22 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = '_airbyte_ads_insights_overall_hashid'
+    partitions = partitions_to_replace,
+    unique_key = '_airbyte_ads_insights_platform_and_device_hashid'
 ) }}
 
--- depends_on: {{ ref('ads_insights_overall_ab4') }}
+-- depends_on: {{ ref('ads_insights_platform_and_device_ab4') }}
 SELECT
-     _airbyte_ads_insights_overall_hashid
+     _airbyte_ads_insights_platform_and_device_hashid
     ,_airbyte_emitted_at
     ,_airbyte_ab_id
     ,ad_id
     ,date_start
     ,date_stop
+    --PLATFORM AND DEVICE
+    ,publisher_platform
+    ,platform_position
+    ,impression_device
     --METRICS
     ,cpc
     ,cpm
@@ -79,13 +84,13 @@ SELECT
     ,estimated_ad_recall_rate_lower_bound
     ,estimated_ad_recall_rate_upper_bound
     ,qualifying_question_qualify_answer_rate
-    ----VIDEO METRICS
+    --VIDEO METRICS
     ,video_played
-    ,video_continuous_2_sec_watched
+    ,video_continuous_2_sec_watched_actions
     ,cost_per_2_sec_continuous_video_view
-    ,video_15_sec_watched
+    ,video_15_sec_watched_actions
     ,cost_per_15_sec_video_view
-    ,video_30_sec_watched
+    ,video_30_sec_watched_actions
     ,cost_per_thruplay
     ,video_p25_watched
     ,video_p50_watched
@@ -96,7 +101,7 @@ SELECT
     ,landing_page_views
     ,shares
     ,conversion_values
-from {{ ref('ads_insights_overall_ab4') }}
+from {{ ref('ads_insights_platform_and_device_ab4') }}
 
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/facebook_marketing/models/1_cta_base/campaign_report_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_base/campaign_report_base.sql
@@ -6,25 +6,31 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = '_account_report_hashid'
+    partitions = partitions_to_replace,
+    unique_key = '_campaign_report_hashid'
 ) }}
 
 -- depends_on: {{ ref('ads_insights_overall_base') }}
 
 with aggregations as (
-select
+
+SELECT
     date_start,
     account_id,
     account_name,
+    campaign_id,
+    campaign_name,
     timestamp_trunc(_airbyte_emitted_at, day) as _airbyte_emitted_at,
     sum(clicks) as clicks,
     sum(impressions) as impressions,
     sum(spend) as spend
-from  {{ ref('ads_insights_overall_base') }}
+FROM  {{ ref('ads_insights_overall_base') }}
 GROUP BY
     date_start,
     account_id,
     account_name,
+    campaign_id,
+    campaign_name,
     timestamp_trunc(_airbyte_emitted_at, day)
 )
 
@@ -33,11 +39,13 @@ SELECT
     {{ dbt_utils.surrogate_key([
     'date_start',
     'account_id',
-    'account_name'
-    ]) }} as _account_report_hashid
+    'account_name',
+    'campaign_id',
+    'campaign_name'
+    ]) }} as _campaign_report_hashid
     ,current_timestamp as _airbyte_normalized_at
 FROM aggregations
 
 {% if is_incremental() %}
-where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})
+WHERE timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})
 {% endif %}

--- a/dbt-cta/facebook_marketing/models/1_cta_base/campaigns_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_base/campaigns_base.sql
@@ -6,6 +6,7 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    partitions = partitions_to_replace,
     unique_key = '_airbyte_campaigns_hashid'
 ) }}
 


### PR DESCRIPTION
@emily-flambe This is the change i was thinking. Its the whole replace partitions with todays and yesterdays date with latest data from raw (todays data). What ya think? or should we just make the matviews `full-refresh = True`