### PR TITLE
fix: make freshdesk incremental models, full-refresh

### DIFF
--- a/dbt-cta/freshdesk/models/1_cta_base/satisfaction_rating_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_base/satisfaction_rating_base.sql
@@ -1,10 +1,13 @@
+{% set partitions_to_replace = [
+    'timestamp_trunc(current_timestamp, day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+] %}
+
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    materialized = "incremental",
-    incremental_strategy = "merge",
-    on_schema_change = "sync_all_columns",
+    partitions = partitions_to_replace,
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
@@ -24,6 +27,8 @@ select
     _airbyte_emitted_at,
 from {{ ref('satisfaction_rating_ab2') }}
 -- satisfaction_ratings from {{ source('cta', '_airbyte_raw_satisfaction_ratings') }}
-where 1 = 1
-{{ incremental_clause('_airbyte_emitted_at') }}
+{% if is_incremental() %}
+where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})
+{% endif %}
+
 


### PR DESCRIPTION
Alright update on this, I believe the initial failure came from removing the `should_full_refresh` macro the `tickets` base table and matview didnt have the `_airbyte` column so were getting dropped and re-created daily. So this was actually the first time this model tried to run incrementally which didnt work 😢. So with that i decided just to make all incremental streams for freshdesk into full-refresh streams. 

Another finding is that by default the Freshdesk connector pulls data only for the last 30 days of the day its running instead of all available data (which is what the docs say it will do) so I had set a start date on the Airbyte Stream ( i picked 2022-01-01) and reset the stream.