### PR TITLE
feat: init_dbt.sh should not create all those dang backup files

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -39,7 +39,7 @@ PROJECT_ID=<CTA project id>
 PROJECT_NAME=<dev|prod>
 WORKSPACE_ID=<workspace ID>
 export WORKSPACE_ID="$WORKSPACE_ID";
-gcloud compute ssh --project=$PROJECT_ID -zone=us-central1-a $(gcloud compute instance-groups managed list-instances tf-igm-airbyte-${PROJECT_NAME} \
+gcloud compute ssh --project=$PROJECT_ID --zone=us-central1-a $(gcloud compute instance-groups managed list-instances tf-igm-airbyte-${PROJECT_NAME} \
  --zone=us-central1-a \
  --project=$PROJECT_ID \
  --filter="STATUS=running" \

--- a/utils/init_dbt
+++ b/utils/init_dbt
@@ -54,8 +54,8 @@ printf '%s' "Moving ctes..."
 mv "$DIR_NAME"/models/airbyte_ctes*/**/ "$DIR_NAME"/models/0_ctes
 printf 'Modifying references in 0_ctes for %s' "$DIR_NAME"
 for file in $(ls "$DIR_NAME"/models/0_ctes/); do
-	sed -i -E 's/\`\prod.*\(_airbyte_raw_[^ ]*\)/{{ source("'"cta"'", "'"\1"'" \) }}/g' "$DIR_NAME"/models/0_ctes/$file;
-    sed -i -E 's/\`\prod.*\(\`\w+\`[^ ]*\)/{{ source("'"cta"'", "'"\1"'" \) }}/g' "$DIR_NAME"/models/0_ctes/$file;
+	sed -i 's/\`\prod.*\(_airbyte_raw_[^ ]*\)/{{ source("'"cta"'", "'"\1"'" \) }}/g' "$DIR_NAME"/models/0_ctes/$file;
+    sed -i 's/\`\prod.*\(\`\w+\`[^ ]*\)/{{ source("'"cta"'", "'"\1"'" \) }}/g' "$DIR_NAME"/models/0_ctes/$file;
 done
 
 # Move Airbyte-generated full-refresh tables and modify references

--- a/utils/init_dbt
+++ b/utils/init_dbt
@@ -66,7 +66,7 @@ if [[ -d "${DIR_NAME}/models/airbyte_tables/" ]]; then
     
     printf 'Modifying references in 1_cta_base for %s' "$DIR_NAME"
     for file in $(ls "$DIR_NAME"/models/1_cta_tables/); do
-	    sed -i -E 's/\`\prod.*\(_airbyte_raw_[^ ]*\)/{{ source("'"cta"'", "'"\1"'" \) }}/g' "$DIR_NAME"/models/1_cta_tables/$file;
+	    sed -i 's/\`\prod.*\(_airbyte_raw_[^ ]*\)/{{ source("'"cta"'", "'"\1"'" \) }}/g' "$DIR_NAME"/models/1_cta_tables/$file;
     done
 fi
 
@@ -78,7 +78,7 @@ if [[ -d "${DIR_NAME}/models/airbyte_incremental/" ]]; then
 
     printf 'Modifying references in 1_cta_base for %s' "$DIR_NAME"
     for file in $(ls "$DIR_NAME"/models/1_cta_base/); do
-	    sed -i -E 's/\`\prod.*\(_airbyte_raw_[^ ]*\)/{{ source("'"cta"'", "'"\1"'" \) }}/g' "$DIR_NAME"/models/1_cta_base/$file;
+	    sed -i 's/\`\prod.*\(_airbyte_raw_[^ ]*\)/{{ source("'"cta"'", "'"\1"'" \) }}/g' "$DIR_NAME"/models/1_cta_base/$file;
     done
 fi
 
@@ -89,4 +89,3 @@ rm -rf "$DIR_NAME"/models/airbyte_ctes "$DIR_NAME"/models/airbyte_incremental "$
 printf 'Modifying references in 0_ctes for %s' "$DIR_NAME"
 
 gum format "Have a proggy day! 🐸"
-


### PR DESCRIPTION
@michaelefisher I know there was some reason for adding the `-E` flag to these `sed` commands, but can you remind me what it was? It's causing the script to generate a bunch of backup files, which is something I was hoping we could avoid (see below).

If we need to keep it, I can add a step to remove files with the `-E` suffix, but it would be even cooler for them not to exist?

eg.:
```
spoke_sua_all_campaign_ab1.sql
spoke_sua_all_campaign_ab1.sql-E
spoke_sua_all_campaign_ab2.sql
spoke_sua_all_campaign_ab2.sql-E
spoke_sua_all_campaign_ab3.sql
spoke_sua_all_campaign_ab3.sql-E
...
```
