### PR TITLE
Add codegen script to generate `schema.yml` files [DE-182]

### DIFF
--- a/dbt-cta/actblue/models/1_cta_base/_1_cta_base__models.yml
+++ b/dbt-cta/actblue/models/1_cta_base/_1_cta_base__models.yml
@@ -1,0 +1,538 @@
+version: 2
+
+models:
+
+  - name: managed_form_contributions_stream
+    description: ''
+    columns:
+      - name: fee
+        description: ''
+      - name: date
+        description: ''
+      - name: amount
+        description: ''
+      - name: mobile
+        description: ''
+      - name: approved
+        description: ''
+      - name: comments
+        description: ''
+      - name: donor_id
+        description: ''
+      - name: apple_pay
+        description: ''
+      - name: donor_zip
+        description: ''
+      - name: recipient
+        description: ''
+      - name: refund_id
+        description: ''
+      - name: check_date
+        description: ''
+      - name: donor_city
+        description: ''
+      - name: partner_id
+        description: ''
+      - name: payment_id
+        description: ''
+      - name: receipt_id
+        description: ''
+      - name: donor_addr1
+        description: ''
+      - name: donor_addr2
+        description: ''
+      - name: donor_email
+        description: ''
+      - name: donor_phone
+        description: ''
+      - name: donor_state
+        description: ''
+      - name: double_down
+        description: ''
+      - name: lineitem_id
+        description: ''
+      - name: merchant_id
+        description: ''
+      - name: recovery_id
+        description: ''
+      - name: refund_date
+        description: ''
+      - name: ab_test_name
+        description: ''
+      - name: ab_variation
+        description: ''
+      - name: check_number
+        description: ''
+      - name: employer_zip
+        description: ''
+      - name: payment_date
+        description: ''
+      - name: recipient_id
+        description: ''
+      - name: recur_weekly
+        description: ''
+      - name: shipping_zip
+        description: ''
+      - name: donor_country
+        description: ''
+      - name: employer_city
+        description: ''
+      - name: fundraiser_id
+        description: ''
+      - name: gift_declined
+        description: ''
+      - name: recovery_date
+        description: ''
+      - name: shipping_city
+        description: ''
+      - name: donor_employer
+        description: ''
+      - name: employer_addr1
+        description: ''
+      - name: employer_addr2
+        description: ''
+      - name: employer_state
+        description: ''
+      - name: reference_code
+        description: ''
+      - name: shipping_addr1
+        description: ''
+      - name: shipping_state
+        description: ''
+      - name: disbursement_id
+        description: ''
+      - name: donor_last_name
+        description: ''
+      - name: gift_identifier
+        description: ''
+      - name: smart_recurring
+        description: ''
+      - name: donor_first_name
+        description: ''
+      - name: donor_occupation
+        description: ''
+      - name: employer_country
+        description: ''
+      - name: fundraising_page
+        description: ''
+      - name: reference_code_2
+        description: ''
+      - name: shipping_country
+        description: ''
+      - name: disbursement_date
+        description: ''
+      - name: recurrence_number
+        description: ''
+      - name: smart_boost_shown
+        description: ''
+      - name: new_express_signup
+        description: ''
+      - name: recipient_election
+        description: ''
+      - name: smart_boost_amount
+        description: ''
+      - name: fundraising_partner
+        description: ''
+      - name: recipient_committee
+        description: ''
+      - name: text_message_opt_in
+        description: ''
+      - name: actblue_express_lane
+        description: ''
+      - name: custom_field_1_label
+        description: ''
+      - name: custom_field_1_value
+        description: ''
+      - name: actblue_express_donor
+        description: ''
+      - name: partner_contact_email
+        description: ''
+      - name: recurring_total_months
+        description: ''
+      - name: recurring_upsell_shown
+        description: ''
+      - name: fundraiser_recipient_id
+        description: ''
+      - name: weekly_recurring_amount
+        description: ''
+      - name: fundraiser_contact_email
+        description: ''
+      - name: monthly_recurring_amount
+        description: ''
+      - name: partner_contact_last_name
+        description: ''
+      - name: partner_contact_first_name
+        description: ''
+      - name: recurring_upsell_succeeded
+        description: ''
+      - name: fundraiser_contact_last_name
+        description: ''
+      - name: fundraiser_contact_first_name
+        description: ''
+      - name: card_replaced_by_account_updater
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+      - name: _airbyte_emitted_at
+        description: ''
+      - name: _airbyte_normalized_at
+        description: ''
+      - name: _airbyte_managed_form_contributions_stream_hashid
+        description: ''
+
+  - name: refunded_contributions_stream
+    description: ''
+    columns:
+      - name: fee
+        description: ''
+      - name: date
+        description: ''
+      - name: amount
+        description: ''
+      - name: mobile
+        description: ''
+      - name: approved
+        description: ''
+      - name: comments
+        description: ''
+      - name: donor_id
+        description: ''
+      - name: apple_pay
+        description: ''
+      - name: donor_zip
+        description: ''
+      - name: recipient
+        description: ''
+      - name: refund_id
+        description: ''
+      - name: check_date
+        description: ''
+      - name: donor_city
+        description: ''
+      - name: partner_id
+        description: ''
+      - name: payment_id
+        description: ''
+      - name: receipt_id
+        description: ''
+      - name: donor_addr1
+        description: ''
+      - name: donor_addr2
+        description: ''
+      - name: donor_email
+        description: ''
+      - name: donor_phone
+        description: ''
+      - name: donor_state
+        description: ''
+      - name: double_down
+        description: ''
+      - name: lineitem_id
+        description: ''
+      - name: merchant_id
+        description: ''
+      - name: recovery_id
+        description: ''
+      - name: refund_date
+        description: ''
+      - name: ab_test_name
+        description: ''
+      - name: ab_variation
+        description: ''
+      - name: check_number
+        description: ''
+      - name: employer_zip
+        description: ''
+      - name: payment_date
+        description: ''
+      - name: recipient_id
+        description: ''
+      - name: recur_weekly
+        description: ''
+      - name: shipping_zip
+        description: ''
+      - name: donor_country
+        description: ''
+      - name: employer_city
+        description: ''
+      - name: fundraiser_id
+        description: ''
+      - name: gift_declined
+        description: ''
+      - name: recovery_date
+        description: ''
+      - name: shipping_city
+        description: ''
+      - name: donor_employer
+        description: ''
+      - name: employer_addr1
+        description: ''
+      - name: employer_addr2
+        description: ''
+      - name: employer_state
+        description: ''
+      - name: reference_code
+        description: ''
+      - name: shipping_addr1
+        description: ''
+      - name: shipping_state
+        description: ''
+      - name: disbursement_id
+        description: ''
+      - name: donor_last_name
+        description: ''
+      - name: gift_identifier
+        description: ''
+      - name: smart_recurring
+        description: ''
+      - name: donor_first_name
+        description: ''
+      - name: donor_occupation
+        description: ''
+      - name: employer_country
+        description: ''
+      - name: fundraising_page
+        description: ''
+      - name: reference_code_2
+        description: ''
+      - name: shipping_country
+        description: ''
+      - name: disbursement_date
+        description: ''
+      - name: recurrence_number
+        description: ''
+      - name: smart_boost_shown
+        description: ''
+      - name: new_express_signup
+        description: ''
+      - name: recipient_election
+        description: ''
+      - name: smart_boost_amount
+        description: ''
+      - name: fundraising_partner
+        description: ''
+      - name: recipient_committee
+        description: ''
+      - name: text_message_opt_in
+        description: ''
+      - name: actblue_express_lane
+        description: ''
+      - name: custom_field_1_label
+        description: ''
+      - name: custom_field_1_value
+        description: ''
+      - name: actblue_express_donor
+        description: ''
+      - name: partner_contact_email
+        description: ''
+      - name: recurring_total_months
+        description: ''
+      - name: recurring_upsell_shown
+        description: ''
+      - name: fundraiser_recipient_id
+        description: ''
+      - name: weekly_recurring_amount
+        description: ''
+      - name: fundraiser_contact_email
+        description: ''
+      - name: monthly_recurring_amount
+        description: ''
+      - name: partner_contact_last_name
+        description: ''
+      - name: partner_contact_first_name
+        description: ''
+      - name: recurring_upsell_succeeded
+        description: ''
+      - name: fundraiser_contact_last_name
+        description: ''
+      - name: fundraiser_contact_first_name
+        description: ''
+      - name: card_replaced_by_account_updater
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+      - name: _airbyte_emitted_at
+        description: ''
+      - name: _airbyte_normalized_at
+        description: ''
+      - name: _airbyte_refunded_contributions_stream_hashid
+        description: ''
+
+  - name: paid_contributions_stream
+    description: ''
+    columns:
+      - name: fee
+        description: ''
+      - name: date
+        description: ''
+      - name: amount
+        description: ''
+      - name: mobile
+        description: ''
+      - name: approved
+        description: ''
+      - name: comments
+        description: ''
+      - name: donor_id
+        description: ''
+      - name: apple_pay
+        description: ''
+      - name: donor_zip
+        description: ''
+      - name: recipient
+        description: ''
+      - name: refund_id
+        description: ''
+      - name: check_date
+        description: ''
+      - name: donor_city
+        description: ''
+      - name: partner_id
+        description: ''
+      - name: payment_id
+        description: ''
+      - name: receipt_id
+        description: ''
+      - name: donor_addr1
+        description: ''
+      - name: donor_addr2
+        description: ''
+      - name: donor_email
+        description: ''
+      - name: donor_phone
+        description: ''
+      - name: donor_state
+        description: ''
+      - name: double_down
+        description: ''
+      - name: lineitem_id
+        description: ''
+      - name: merchant_id
+        description: ''
+      - name: recovery_id
+        description: ''
+      - name: refund_date
+        description: ''
+      - name: ab_test_name
+        description: ''
+      - name: ab_variation
+        description: ''
+      - name: check_number
+        description: ''
+      - name: employer_zip
+        description: ''
+      - name: payment_date
+        description: ''
+      - name: recipient_id
+        description: ''
+      - name: recur_weekly
+        description: ''
+      - name: shipping_zip
+        description: ''
+      - name: donor_country
+        description: ''
+      - name: employer_city
+        description: ''
+      - name: fundraiser_id
+        description: ''
+      - name: gift_declined
+        description: ''
+      - name: recovery_date
+        description: ''
+      - name: shipping_city
+        description: ''
+      - name: donor_employer
+        description: ''
+      - name: employer_addr1
+        description: ''
+      - name: employer_addr2
+        description: ''
+      - name: employer_state
+        description: ''
+      - name: reference_code
+        description: ''
+      - name: shipping_addr1
+        description: ''
+      - name: shipping_state
+        description: ''
+      - name: disbursement_id
+        description: ''
+      - name: donor_last_name
+        description: ''
+      - name: gift_identifier
+        description: ''
+      - name: smart_recurring
+        description: ''
+      - name: donor_first_name
+        description: ''
+      - name: donor_occupation
+        description: ''
+      - name: employer_country
+        description: ''
+      - name: fundraising_page
+        description: ''
+      - name: reference_code_2
+        description: ''
+      - name: shipping_country
+        description: ''
+      - name: disbursement_date
+        description: ''
+      - name: recurrence_number
+        description: ''
+      - name: smart_boost_shown
+        description: ''
+      - name: new_express_signup
+        description: ''
+      - name: recipient_election
+        description: ''
+      - name: smart_boost_amount
+        description: ''
+      - name: fundraising_partner
+        description: ''
+      - name: recipient_committee
+        description: ''
+      - name: text_message_opt_in
+        description: ''
+      - name: actblue_express_lane
+        description: ''
+      - name: custom_field_1_label
+        description: ''
+      - name: custom_field_1_value
+        description: ''
+      - name: actblue_express_donor
+        description: ''
+      - name: partner_contact_email
+        description: ''
+      - name: recurring_total_months
+        description: ''
+      - name: recurring_upsell_shown
+        description: ''
+      - name: fundraiser_recipient_id
+        description: ''
+      - name: weekly_recurring_amount
+        description: ''
+      - name: fundraiser_contact_email
+        description: ''
+      - name: monthly_recurring_amount
+        description: ''
+      - name: partner_contact_last_name
+        description: ''
+      - name: partner_contact_first_name
+        description: ''
+      - name: recurring_upsell_succeeded
+        description: ''
+      - name: fundraiser_contact_last_name
+        description: ''
+      - name: fundraiser_contact_first_name
+        description: ''
+      - name: card_replaced_by_account_updater
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+      - name: _airbyte_emitted_at
+        description: ''
+      - name: _airbyte_normalized_at
+        description: ''
+      - name: _airbyte_paid_contributions_stream_hashid
+        description: ''
+

--- a/dbt-cta/actblue/models/2_partner_matviews/_2_partner_matviews__models.yml
+++ b/dbt-cta/actblue/models/2_partner_matviews/_2_partner_matviews__models.yml
@@ -1,0 +1,514 @@
+version: 2
+
+models:
+
+  - name: paid_contributions
+    description: ''
+    columns:
+      - name: fee
+        description: ''
+      - name: date
+        description: ''
+      - name: amount
+        description: ''
+      - name: mobile
+        description: ''
+      - name: approved
+        description: ''
+      - name: comments
+        description: ''
+      - name: donor_id
+        description: ''
+      - name: apple_pay
+        description: ''
+      - name: donor_zip
+        description: ''
+      - name: recipient
+        description: ''
+      - name: refund_id
+        description: ''
+      - name: check_date
+        description: ''
+      - name: donor_city
+        description: ''
+      - name: partner_id
+        description: ''
+      - name: payment_id
+        description: ''
+      - name: receipt_id
+        description: ''
+      - name: donor_addr1
+        description: ''
+      - name: donor_addr2
+        description: ''
+      - name: donor_email
+        description: ''
+      - name: donor_phone
+        description: ''
+      - name: donor_state
+        description: ''
+      - name: double_down
+        description: ''
+      - name: lineitem_id
+        description: ''
+      - name: merchant_id
+        description: ''
+      - name: recovery_id
+        description: ''
+      - name: refund_date
+        description: ''
+      - name: ab_test_name
+        description: ''
+      - name: ab_variation
+        description: ''
+      - name: check_number
+        description: ''
+      - name: employer_zip
+        description: ''
+      - name: payment_date
+        description: ''
+      - name: recipient_id
+        description: ''
+      - name: recur_weekly
+        description: ''
+      - name: shipping_zip
+        description: ''
+      - name: donor_country
+        description: ''
+      - name: employer_city
+        description: ''
+      - name: fundraiser_id
+        description: ''
+      - name: gift_declined
+        description: ''
+      - name: recovery_date
+        description: ''
+      - name: shipping_city
+        description: ''
+      - name: donor_employer
+        description: ''
+      - name: employer_addr1
+        description: ''
+      - name: employer_addr2
+        description: ''
+      - name: employer_state
+        description: ''
+      - name: reference_code
+        description: ''
+      - name: shipping_addr1
+        description: ''
+      - name: shipping_state
+        description: ''
+      - name: disbursement_id
+        description: ''
+      - name: donor_last_name
+        description: ''
+      - name: gift_identifier
+        description: ''
+      - name: smart_recurring
+        description: ''
+      - name: donor_first_name
+        description: ''
+      - name: donor_occupation
+        description: ''
+      - name: employer_country
+        description: ''
+      - name: fundraising_page
+        description: ''
+      - name: reference_code_2
+        description: ''
+      - name: shipping_country
+        description: ''
+      - name: disbursement_date
+        description: ''
+      - name: recurrence_number
+        description: ''
+      - name: smart_boost_shown
+        description: ''
+      - name: new_express_signup
+        description: ''
+      - name: recipient_election
+        description: ''
+      - name: smart_boost_amount
+        description: ''
+      - name: fundraising_partner
+        description: ''
+      - name: recipient_committee
+        description: ''
+      - name: text_message_opt_in
+        description: ''
+      - name: actblue_express_lane
+        description: ''
+      - name: custom_field_1_label
+        description: ''
+      - name: custom_field_1_value
+        description: ''
+      - name: actblue_express_donor
+        description: ''
+      - name: partner_contact_email
+        description: ''
+      - name: recurring_total_months
+        description: ''
+      - name: recurring_upsell_shown
+        description: ''
+      - name: fundraiser_recipient_id
+        description: ''
+      - name: weekly_recurring_amount
+        description: ''
+      - name: fundraiser_contact_email
+        description: ''
+      - name: monthly_recurring_amount
+        description: ''
+      - name: partner_contact_last_name
+        description: ''
+      - name: partner_contact_first_name
+        description: ''
+      - name: recurring_upsell_succeeded
+        description: ''
+      - name: fundraiser_contact_last_name
+        description: ''
+      - name: fundraiser_contact_first_name
+        description: ''
+      - name: card_replaced_by_account_updater
+        description: ''
+
+  - name: managed_form_contributions
+    description: ''
+    columns:
+      - name: fee
+        description: ''
+      - name: date
+        description: ''
+      - name: amount
+        description: ''
+      - name: mobile
+        description: ''
+      - name: approved
+        description: ''
+      - name: comments
+        description: ''
+      - name: donor_id
+        description: ''
+      - name: apple_pay
+        description: ''
+      - name: donor_zip
+        description: ''
+      - name: recipient
+        description: ''
+      - name: refund_id
+        description: ''
+      - name: check_date
+        description: ''
+      - name: donor_city
+        description: ''
+      - name: partner_id
+        description: ''
+      - name: payment_id
+        description: ''
+      - name: receipt_id
+        description: ''
+      - name: donor_addr1
+        description: ''
+      - name: donor_addr2
+        description: ''
+      - name: donor_email
+        description: ''
+      - name: donor_phone
+        description: ''
+      - name: donor_state
+        description: ''
+      - name: double_down
+        description: ''
+      - name: lineitem_id
+        description: ''
+      - name: merchant_id
+        description: ''
+      - name: recovery_id
+        description: ''
+      - name: refund_date
+        description: ''
+      - name: ab_test_name
+        description: ''
+      - name: ab_variation
+        description: ''
+      - name: check_number
+        description: ''
+      - name: employer_zip
+        description: ''
+      - name: payment_date
+        description: ''
+      - name: recipient_id
+        description: ''
+      - name: recur_weekly
+        description: ''
+      - name: shipping_zip
+        description: ''
+      - name: donor_country
+        description: ''
+      - name: employer_city
+        description: ''
+      - name: fundraiser_id
+        description: ''
+      - name: gift_declined
+        description: ''
+      - name: recovery_date
+        description: ''
+      - name: shipping_city
+        description: ''
+      - name: donor_employer
+        description: ''
+      - name: employer_addr1
+        description: ''
+      - name: employer_addr2
+        description: ''
+      - name: employer_state
+        description: ''
+      - name: reference_code
+        description: ''
+      - name: shipping_addr1
+        description: ''
+      - name: shipping_state
+        description: ''
+      - name: disbursement_id
+        description: ''
+      - name: donor_last_name
+        description: ''
+      - name: gift_identifier
+        description: ''
+      - name: smart_recurring
+        description: ''
+      - name: donor_first_name
+        description: ''
+      - name: donor_occupation
+        description: ''
+      - name: employer_country
+        description: ''
+      - name: fundraising_page
+        description: ''
+      - name: reference_code_2
+        description: ''
+      - name: shipping_country
+        description: ''
+      - name: disbursement_date
+        description: ''
+      - name: recurrence_number
+        description: ''
+      - name: smart_boost_shown
+        description: ''
+      - name: new_express_signup
+        description: ''
+      - name: recipient_election
+        description: ''
+      - name: smart_boost_amount
+        description: ''
+      - name: fundraising_partner
+        description: ''
+      - name: recipient_committee
+        description: ''
+      - name: text_message_opt_in
+        description: ''
+      - name: actblue_express_lane
+        description: ''
+      - name: custom_field_1_label
+        description: ''
+      - name: custom_field_1_value
+        description: ''
+      - name: actblue_express_donor
+        description: ''
+      - name: partner_contact_email
+        description: ''
+      - name: recurring_total_months
+        description: ''
+      - name: recurring_upsell_shown
+        description: ''
+      - name: fundraiser_recipient_id
+        description: ''
+      - name: weekly_recurring_amount
+        description: ''
+      - name: fundraiser_contact_email
+        description: ''
+      - name: monthly_recurring_amount
+        description: ''
+      - name: partner_contact_last_name
+        description: ''
+      - name: partner_contact_first_name
+        description: ''
+      - name: recurring_upsell_succeeded
+        description: ''
+      - name: fundraiser_contact_last_name
+        description: ''
+      - name: fundraiser_contact_first_name
+        description: ''
+      - name: card_replaced_by_account_updater
+        description: ''
+
+  - name: refunded_contributions
+    description: ''
+    columns:
+      - name: fee
+        description: ''
+      - name: date
+        description: ''
+      - name: amount
+        description: ''
+      - name: mobile
+        description: ''
+      - name: approved
+        description: ''
+      - name: comments
+        description: ''
+      - name: donor_id
+        description: ''
+      - name: apple_pay
+        description: ''
+      - name: donor_zip
+        description: ''
+      - name: recipient
+        description: ''
+      - name: refund_id
+        description: ''
+      - name: check_date
+        description: ''
+      - name: donor_city
+        description: ''
+      - name: partner_id
+        description: ''
+      - name: payment_id
+        description: ''
+      - name: receipt_id
+        description: ''
+      - name: donor_addr1
+        description: ''
+      - name: donor_addr2
+        description: ''
+      - name: donor_email
+        description: ''
+      - name: donor_phone
+        description: ''
+      - name: donor_state
+        description: ''
+      - name: double_down
+        description: ''
+      - name: lineitem_id
+        description: ''
+      - name: merchant_id
+        description: ''
+      - name: recovery_id
+        description: ''
+      - name: refund_date
+        description: ''
+      - name: ab_test_name
+        description: ''
+      - name: ab_variation
+        description: ''
+      - name: check_number
+        description: ''
+      - name: employer_zip
+        description: ''
+      - name: payment_date
+        description: ''
+      - name: recipient_id
+        description: ''
+      - name: recur_weekly
+        description: ''
+      - name: shipping_zip
+        description: ''
+      - name: donor_country
+        description: ''
+      - name: employer_city
+        description: ''
+      - name: fundraiser_id
+        description: ''
+      - name: gift_declined
+        description: ''
+      - name: recovery_date
+        description: ''
+      - name: shipping_city
+        description: ''
+      - name: donor_employer
+        description: ''
+      - name: employer_addr1
+        description: ''
+      - name: employer_addr2
+        description: ''
+      - name: employer_state
+        description: ''
+      - name: reference_code
+        description: ''
+      - name: shipping_addr1
+        description: ''
+      - name: shipping_state
+        description: ''
+      - name: disbursement_id
+        description: ''
+      - name: donor_last_name
+        description: ''
+      - name: gift_identifier
+        description: ''
+      - name: smart_recurring
+        description: ''
+      - name: donor_first_name
+        description: ''
+      - name: donor_occupation
+        description: ''
+      - name: employer_country
+        description: ''
+      - name: fundraising_page
+        description: ''
+      - name: reference_code_2
+        description: ''
+      - name: shipping_country
+        description: ''
+      - name: disbursement_date
+        description: ''
+      - name: recurrence_number
+        description: ''
+      - name: smart_boost_shown
+        description: ''
+      - name: new_express_signup
+        description: ''
+      - name: recipient_election
+        description: ''
+      - name: smart_boost_amount
+        description: ''
+      - name: fundraising_partner
+        description: ''
+      - name: recipient_committee
+        description: ''
+      - name: text_message_opt_in
+        description: ''
+      - name: actblue_express_lane
+        description: ''
+      - name: custom_field_1_label
+        description: ''
+      - name: custom_field_1_value
+        description: ''
+      - name: actblue_express_donor
+        description: ''
+      - name: partner_contact_email
+        description: ''
+      - name: recurring_total_months
+        description: ''
+      - name: recurring_upsell_shown
+        description: ''
+      - name: fundraiser_recipient_id
+        description: ''
+      - name: weekly_recurring_amount
+        description: ''
+      - name: fundraiser_contact_email
+        description: ''
+      - name: monthly_recurring_amount
+        description: ''
+      - name: partner_contact_last_name
+        description: ''
+      - name: partner_contact_first_name
+        description: ''
+      - name: recurring_upsell_succeeded
+        description: ''
+      - name: fundraiser_contact_last_name
+        description: ''
+      - name: fundraiser_contact_first_name
+        description: ''
+      - name: card_replaced_by_account_updater
+        description: ''
+

--- a/dbt-cta/packages.yml
+++ b/dbt-cta/packages.yml
@@ -1,11 +1,9 @@
 # add dependencies. these will get pulled during the `dbt deps` process.
 
 packages:
-  - git: "https://github.com/fishtown-analytics/dbt-utils.git"
-    revision: 0.8.5
   - git: "https://github.com/community-tech-alliance/dbt-materialized-views.git"
     revision: 1.0.1
   - git: "https://github.com/calogica/dbt-expectations.git"
     revision: 0.8.2
-  - git: "https://github.com/calogica/dbt-date.git"
-    revision: 0.5.0
+  - git: "https://github.com/dbt-labs/dbt-codegen.git"
+    revision: 0.7.0

--- a/utils/README.md
+++ b/utils/README.md
@@ -63,3 +63,30 @@ Because CTA uses an Instance Group Manager, the instance name changes regularly 
 ### Not CTA, but still running Airbyte in a GCE instance:
 
 You can use the same command - just replace the ```$(gcloud compute instance-groups managed list-instances ...)``` command with the name of the GCE instance you're using to run Airbyte.
+
+
+# generate_schema_yml.py
+This script generates starter schema.yml files for a new dbt project. It uses dbt's
+[codegen](https://github.com/dbt-labs/dbt-codegen) package to run a series of 
+`generate_model_yaml` commands, and then aggregates them all together in a single
+yaml file.
+
+## Requirements
+1. Have all the necessary environmental variables set to run dbt, including `SYNC_NAME`.
+ Make sure to run `dbt deps` to install the codegen package.
+2. Be in the `/dbt-cta` directory
+3. Run `python ./utils/generate_schema_yml.py`
+
+## Limitations
+dbt's codegen package does not currently work on ephemeral models. The way our
+directories are structured, we have an entire folder of CTEs, so this script just skips
+those.
+
+## Next Steps
+ - Ideally, this script would generate some basic tests, perhaps configured to set the
+same tests on a set list of column names.
+ - We're using an outdated version of the codegen package to play nicely with our other
+ dependencies. The latest version (`0.9.0`) woudd let us generate schema.yml files for
+ a list of models, rather than parsing them one at a time.
+ - If we have existing schema.yml files, an additional run of this script could be
+ configured to merge in changes, rather than overwriting them.

--- a/utils/generate_schema_yml.py
+++ b/utils/generate_schema_yml.py
@@ -120,7 +120,7 @@ def main():
         if schema_dict:
             out_file = generate_filename(d)
 
-            write_to_file(schema_dict, out_file, overwrite=True)
+            write_to_file(schema_dict, out_file)
 
         # TODO: load current schema.yml file and only add columns
 

--- a/utils/generate_schema_yml.py
+++ b/utils/generate_schema_yml.py
@@ -5,7 +5,7 @@ import yaml
 # As an example, these are the vars set for the mailchimp sync
 DBT_VARS = os.getenv(
     "DBT_VARS",
-    '{"campaigns_raw": "_airbyte_raw_campaigns", "campaigns_base": "campaigns_base", "campaigns": "campaigns"}',
+    '{"campaigns_raw": "_airbyte_raw_campaigns", "campaigns_base": "campaigns_base", "campaigns": "campaigns"}', # noqa
 )
 
 TARGETS = ["cta", "partner"]
@@ -51,7 +51,7 @@ def list_models(dir: str):
 def get_model_config(model_name: str, target: str):
     """Run the dbt codegen generate_model_yaml for a given model and target, and return
     the model yaml parsed to a dictionary"""
-    command = f"""dbt run-operation generate_model_yaml --args '{{"model_name": "{model_name}"}}' -t {target} --vars '{DBT_VARS}'"""
+    command = f"""dbt run-operation generate_model_yaml --args '{{"model_name": "{model_name}"}}' -t {target} --vars '{DBT_VARS}'""" # noqa
 
     stream = os.popen(command)
     output = stream.read()

--- a/utils/generate_schema_yml.py
+++ b/utils/generate_schema_yml.py
@@ -112,7 +112,7 @@ def generate_schema_dict(directory_path):
 
 
 def main():
-    dirs = list_model_directories("actblue")
+    dirs = list_model_directories(os.getenv('SYNC_NAME'))
 
     for d in dirs:
         schema_dict = generate_schema_dict(d)

--- a/utils/generate_schema_yml.py
+++ b/utils/generate_schema_yml.py
@@ -1,0 +1,104 @@
+import os
+
+import yaml
+
+# As an example, these are the vars set for the mailchimp sync
+DBT_VARS = os.getenv('DBT_VARS','{"campaigns_raw": "_airbyte_raw_campaigns", "campaigns_base": "campaigns_base", "campaigns": "campaigns"}')
+
+TARGETS = ['cta', 'partner']
+
+class LineBreakDumper(yaml.SafeDumper):
+    def write_line_break(self, data=None):
+        super().write_line_break(data)
+
+        if len(self.indents) < 3:
+            super().write_line_break()
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super(LineBreakDumper, self).increase_indent(flow, False)
+
+
+def list_model_directories(sync_name):
+    base = f'{sync_name}/models'
+
+    # Will need to tweak this if we nest models any further
+    model_directories = [d for d in [base+'/'+b for b in os.listdir(base)] if os.path.isdir(d)]
+
+    return model_directories
+
+def list_models(dir):
+    files = os.listdir(dir)
+
+    # trim the file extension off
+    models = [f[:-4] for f in files if f.endswith('.sql')]
+
+    return models
+
+def get_model_config(model_name, target):
+    command = f"""dbt run-operation generate_model_yaml --args '{{"model_name": "{model_name}"}}' -t {target} --vars '{DBT_VARS}'"""
+
+    stream = os.popen(command)
+    output = stream.read()
+
+    model_config = output.split("models:")[1]
+
+    model_dict = yaml.load(model_config, Loader=yaml.Loader)
+
+    return model_dict
+
+def write_to_file(dict, filename, overwrite=False):
+    if os.path.exists(filename):
+        if overwrite:
+            print(f'{filename} already exists, overwriting(!).')
+        else:
+            print(f'{filename} already exists, not modifying.')
+
+    with open(filename, 'w') as file:
+        yaml.dump(dict, file, sort_keys=False, Dumper=LineBreakDumper)
+        print(f'YAML written to {filename}!')
+
+def generate_filename(path, postfix =''):
+    yaml_file_name  = f'_{path.split("/")[-1]}__models{postfix}.yml'
+
+    full_path = os.path.join(path, yaml_file_name)
+
+    return full_path
+
+def generate_schema_dict(directory_path):
+    model_directory = directory_path.split('/')[-1]
+
+    if model_directory == '0_ctes':
+        print("Codegen doesn\'t work on emphemeral models, skipping.")
+        return
+    
+    if model_directory[:1] in ['0','1']:
+        target = 'cta'
+    elif model_directory[:1] in ['2','3']:
+        target = 'partner'
+    else:
+        target = None
+
+    models = list_models(directory_path)
+
+    model_configs = [get_model_config(m, target) for m in models]
+
+    # TODO: Add test generation based on column name
+
+    return {'version':2,'models':[m[0] for m in model_configs]}
+
+def main():
+    dirs = list_model_directories('actblue')
+
+    for d in dirs:
+        schema_dict = generate_schema_dict(d)
+
+        if schema_dict:
+            out_file = generate_filename(d)
+
+            write_to_file(schema_dict, out_file, overwrite=True)
+
+        # TODO: load current schema.yml file and only add columns
+
+if __name__ == '__main__':
+    # TODO: add light CLI to control overwrite
+    main()

--- a/utils/generate_schema_yml.py
+++ b/utils/generate_schema_yml.py
@@ -25,7 +25,7 @@ class LineBreakDumper(yaml.SafeDumper):
         return super(LineBreakDumper, self).increase_indent(flow, False)
 
 
-def list_model_directories(sync_name:str):
+def list_model_directories(sync_name: str):
     """Given a sync name, list all the possible model directories"""
     base = f"{sync_name}/models"
 
@@ -37,7 +37,7 @@ def list_model_directories(sync_name:str):
     return model_directories
 
 
-def list_models(dir:str):
+def list_models(dir: str):
     """List all the models (sql files) in a directory, and return a list of model
     names"""
     files = os.listdir(dir)
@@ -48,7 +48,7 @@ def list_models(dir:str):
     return models
 
 
-def get_model_config(model_name:str, target:str):
+def get_model_config(model_name: str, target: str):
     """Run the dbt codegen generate_model_yaml for a given model and target, and return
     the model yaml parsed to a dictionary"""
     command = f"""dbt run-operation generate_model_yaml --args '{{"model_name": "{model_name}"}}' -t {target} --vars '{DBT_VARS}'"""
@@ -63,7 +63,7 @@ def get_model_config(model_name:str, target:str):
     return model_dict
 
 
-def write_to_file(dict:dict, filename:str, overwrite:bool=False):
+def write_to_file(dict: dict, filename: str, overwrite: bool = False):
     """Given a dictionary, write it out as a yaml file, and optionally overwrite at
     the destination"""
     if os.path.exists(filename):

--- a/utils/generate_schema_yml.py
+++ b/utils/generate_schema_yml.py
@@ -12,6 +12,9 @@ TARGETS = ["cta", "partner"]
 
 
 class LineBreakDumper(yaml.SafeDumper):
+    """This is a custom yaml dumper class that adds some additional indents and line
+    breaks"""
+
     def write_line_break(self, data=None):
         super().write_line_break(data)
 
@@ -22,7 +25,8 @@ class LineBreakDumper(yaml.SafeDumper):
         return super(LineBreakDumper, self).increase_indent(flow, False)
 
 
-def list_model_directories(sync_name):
+def list_model_directories(sync_name:str):
+    """Given a sync name, list all the possible model directories"""
     base = f"{sync_name}/models"
 
     # Will need to tweak this if we nest models any further
@@ -33,7 +37,9 @@ def list_model_directories(sync_name):
     return model_directories
 
 
-def list_models(dir):
+def list_models(dir:str):
+    """List all the models (sql files) in a directory, and return a list of model
+    names"""
     files = os.listdir(dir)
 
     # trim the file extension off
@@ -42,7 +48,9 @@ def list_models(dir):
     return models
 
 
-def get_model_config(model_name, target):
+def get_model_config(model_name:str, target:str):
+    """Run the dbt codegen generate_model_yaml for a given model and target, and return
+    the model yaml parsed to a dictionary"""
     command = f"""dbt run-operation generate_model_yaml --args '{{"model_name": "{model_name}"}}' -t {target} --vars '{DBT_VARS}'"""
 
     stream = os.popen(command)
@@ -55,7 +63,9 @@ def get_model_config(model_name, target):
     return model_dict
 
 
-def write_to_file(dict, filename, overwrite=False):
+def write_to_file(dict:dict, filename:str, overwrite:bool=False):
+    """Given a dictionary, write it out as a yaml file, and optionally overwrite at
+    the destination"""
     if os.path.exists(filename):
         if overwrite:
             print(f"{filename} already exists, overwriting(!).")
@@ -68,6 +78,7 @@ def write_to_file(dict, filename, overwrite=False):
 
 
 def generate_filename(path, postfix=""):
+    """Given a dbt model path, generate the schema.yml name, per dbt's best practices"""
     yaml_file_name = f'_{path.split("/")[-1]}__models{postfix}.yml'
 
     full_path = os.path.join(path, yaml_file_name)
@@ -76,6 +87,8 @@ def generate_filename(path, postfix=""):
 
 
 def generate_schema_dict(directory_path):
+    """Given a path to some dbt models, generate a dictionary for a schema.yml file
+    for all models in the directory."""
     model_directory = directory_path.split("/")[-1]
 
     if model_directory == "0_ctes":


### PR DESCRIPTION
This PR adds a python script to automatically generate starter `schema.yml` files for every second-level model directory in a dbt project. This will help is efficiently write tests for our many dbt syncs since we'll just need to add the `test:` dictionaries themselves, as opposed to writing out entire files ourselves.

As a PoC, I generated `schema.yml` config files for our ActBlue sync.