### PR TITLE
FIX:  ad account ids are not a fixed length [DE-255]

### DIFF
--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/ad_account_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/ad_account_base.sql
@@ -9,7 +9,7 @@ select
      id
     ,_airbyte_emitted_at
     ,_airbyte_ab_id
-    ,right(id, 16) as account_id_stripped
+    ,SPLIT(id,'_')[OFFSET(1)] as account_id_stripped
     ,age
     ,name
     ,owner


### PR DESCRIPTION
The id field in the ad_account_base table starts with act_, so we previously used `right(id, 16)` to strip just the numbers but… apparently ad account IDs can be of varying length!

This PR replaces the `right()` function and `SPLIT`s on the underscore.