### PR TITLE
[DE-255] Re-enable Facebook Marketing relationships tests, tweak filter criteria

### DIFF
--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -27,6 +27,7 @@ models:
                 severity: error
                 error_if: ">10"
                 warn_if: ">0"
+                where: "created_time > '2022-01-01'"
       - name: date_start
         description: ''
       - name: date_stop
@@ -66,6 +67,8 @@ models:
           - relationships:
               to: ref('ad_account_base')
               field: account_id_stripped
+              config:
+                where: "created_time > '2022-01-01'"
       - name: adset_name
         description: ''
       - name: unique_ctr
@@ -213,6 +216,8 @@ models:
           - relationships:
               to: ref('ad_account_base')
               field: account_id_stripped
+              config:
+                where: "created_time > '2022-01-01'"
       - name: account_name
         description: ''
       - name: campaign_id
@@ -381,6 +386,8 @@ models:
           - relationships:
               to: ref('ad_account_base')
               field: account_id_stripped
+              config:
+                where: "created_time > '2022-01-01'"
       - name: account_name
         description: ''
       - name: campaign_id
@@ -390,6 +397,8 @@ models:
           - relationships:
               to: ref('campaigns_base')
               field: id
+              config:
+                where: "created_time > '2022-01-01'"
       - name: campaign_name
         description: ''
       - name: _airbyte_emitted_at
@@ -472,6 +481,8 @@ models:
           - relationships:
               to: ref('ad_account_base')
               field: account_id_stripped
+              config:
+                where: "created_time > '2022-01-01'"
       - name: start_time
         description: ''
       - name: buying_type
@@ -556,6 +567,8 @@ models:
           - relationships:
               to: ref('ad_account_base')
               field: account_id_stripped
+              config:
+                where: "created_time > '2022-01-01'"
       - name: image_hash
         description: ''
       - name: link_og_id
@@ -628,6 +641,8 @@ models:
           - relationships:
               to: ref('ad_account_base')
               field: account_id_stripped
+              config:
+                where: "created_time > '2022-01-01'"
       - name: start_time
         description: ''
       - name: campaign_id
@@ -637,6 +652,8 @@ models:
           - relationships:
               to: ref('campaigns_base')
               field: id
+              config:
+                where: "created_time > '2022-01-01'"
       - name: created_time
         description: ''
       - name: daily_budget
@@ -673,6 +690,8 @@ models:
           - relationships:
               to: ref('ad_creatives_base')
               field: id
+              config:
+                where: "created_time > '2022-01-01'"
       - name: name
         description: ''
       - name: status
@@ -686,6 +705,8 @@ models:
           - relationships:
               to: ref('ad_sets_base')
               field: id
+              config:
+                where: "created_time > '2022-01-01'"
       - name: bid_info
         description: ''
       - name: bid_type
@@ -701,6 +722,8 @@ models:
           - relationships:
               to: ref('ad_account_base')
               field: account_id_stripped
+              config:
+                where: "created_time > '2022-01-01'"
       - name: bid_amount
         description: ''
       - name: campaign_id
@@ -710,6 +733,8 @@ models:
           - relationships:
               to: ref('campaigns_base')
               field: id
+              config:
+                where: "created_time > '2022-01-01'"
       - name: created_time
         description: ''
       - name: source_ad_id
@@ -746,6 +771,8 @@ models:
           - relationships:
               to: ref('ads_base')
               field: id
+              config:
+                where: "created_time > '2022-01-01'"
       - name: date_start
         description: ''
       - name: date_stop
@@ -791,6 +818,8 @@ models:
           - relationships:
               to: ref('ad_account_base')
               field: account_id_stripped
+              config:
+                where: "created_time > '2022-01-01'"
       - name: adset_name
         description: ''
       - name: unique_ctr

--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -23,6 +23,9 @@ models:
           - relationships:
               to: ref('ads_base')
               field: id
+              # There are a handful of edge cases where ads appear in the insights table
+              # but not the ads table, likely as a result of how Airbyte handles date
+              # filtering. We can safely ignore these cases.
               config:
                 severity: error
                 error_if: ">10"
@@ -773,10 +776,15 @@ models:
           - relationships:
               to: ref('ads_base')
               field: id
-              # Depending on how airbyte is configured, we may have insights records for
-              # ads that are inactive/not in the ads table
+              description:
+              # There are a handful of edge cases where ads appear in the insights table
+              # but not the ads table, likely as a result of how Airbyte handles date
+              # filtering. We can safely ignore these cases.
               config:
                 where: "date_start > '2022-01-01' and spend > 0"
+                severity: error
+                error_if: ">10"
+                warn_if: ">0"
       - name: date_start
         description: ''
       - name: date_stop

--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -217,7 +217,7 @@ models:
               to: ref('ad_account_base')
               field: account_id_stripped
               config:
-                where: "created_time > '2022-01-01'"
+                where: "date_start > '2022-01-01'"
       - name: account_name
         description: ''
       - name: campaign_id
@@ -387,7 +387,7 @@ models:
               to: ref('ad_account_base')
               field: account_id_stripped
               config:
-                where: "created_time > '2022-01-01'"
+                where: "date_start > '2022-01-01'"
       - name: account_name
         description: ''
       - name: campaign_id
@@ -397,8 +397,10 @@ models:
           - relationships:
               to: ref('campaigns_base')
               field: id
+              # Depending on how airbyte is configured, we may have insights records for
+              # campaigns that are inactive/not in the campaigns table
               config:
-                where: "created_time > '2022-01-01'"
+                where: "date_start > '2022-01-01' and spend > 0"
       - name: campaign_name
         description: ''
       - name: _airbyte_emitted_at
@@ -567,8 +569,6 @@ models:
           - relationships:
               to: ref('ad_account_base')
               field: account_id_stripped
-              config:
-                where: "created_time > '2022-01-01'"
       - name: image_hash
         description: ''
       - name: link_og_id
@@ -772,7 +772,7 @@ models:
               to: ref('ads_base')
               field: id
               config:
-                where: "created_time > '2022-01-01'"
+                where: "date_start > '2022-01-01'"
       - name: date_start
         description: ''
       - name: date_stop

--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -20,13 +20,13 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ads_base')
-          #     field: id
-          #     config:
-          #       severity: error
-          #       error_if: ">10"
-          #       warn_if: ">0"
+          - relationships:
+              to: ref('ads_base')
+              field: id
+              config:
+                severity: error
+                error_if: ">10"
+                warn_if: ">0"
       - name: date_start
         description: ''
       - name: date_stop
@@ -63,9 +63,9 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ad_account_base')
-          #     field: account_id_stripped
+          - relationships:
+              to: ref('ad_account_base')
+              field: account_id_stripped
       - name: adset_name
         description: ''
       - name: unique_ctr
@@ -210,9 +210,9 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ad_account_base')
-          #     field: account_id_stripped
+          - relationships:
+              to: ref('ad_account_base')
+              field: account_id_stripped
       - name: account_name
         description: ''
       - name: campaign_id
@@ -378,18 +378,18 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ad_account_base')
-          #     field: account_id_stripped
+          - relationships:
+              to: ref('ad_account_base')
+              field: account_id_stripped
       - name: account_name
         description: ''
       - name: campaign_id
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('campaigns_base')
-          #     field: id
+          - relationships:
+              to: ref('campaigns_base')
+              field: id
       - name: campaign_name
         description: ''
       - name: _airbyte_emitted_at
@@ -425,9 +425,9 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ad_account_base')
-          #     field: account_id_stripped
+          - relationships:
+              to: ref('ad_account_base')
+              field: account_id_stripped
       - name: account_name
         description: ''
       - name: _airbyte_emitted_at
@@ -469,9 +469,9 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ad_account_base')
-          #     field: account_id_stripped
+          - relationships:
+              to: ref('ad_account_base')
+              field: account_id_stripped
       - name: start_time
         description: ''
       - name: buying_type
@@ -553,9 +553,9 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ad_account_base')
-          #     field: account_id_stripped
+          - relationships:
+              to: ref('ad_account_base')
+              field: account_id_stripped
       - name: image_hash
         description: ''
       - name: link_og_id
@@ -625,18 +625,18 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ad_account_base')
-          #     field: account_id_stripped
+          - relationships:
+              to: ref('ad_account_base')
+              field: account_id_stripped
       - name: start_time
         description: ''
-      #- name: campaign_id
-      #  description: ''
-      #  tests:
-      #    - not_null
-      #    - relationships:
-      #        to: ref('campaigns_base')
-      #        field: id
+      - name: campaign_id
+        description: ''
+        tests:
+          - not_null
+          - relationships:
+              to: ref('campaigns_base')
+              field: id
       - name: created_time
         description: ''
       - name: daily_budget
@@ -670,9 +670,9 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ad_creatives_base')
-          #     field: id
+          - relationships:
+              to: ref('ad_creatives_base')
+              field: id
       - name: name
         description: ''
       - name: status
@@ -683,9 +683,9 @@ models:
         description: ''
         tests:
           - not_null
-      #     - relationships:
-      #         to: ref('ad_sets_base')
-      #         field: id
+          - relationships:
+              to: ref('ad_sets_base')
+              field: id
       - name: bid_info
         description: ''
       - name: bid_type
@@ -698,18 +698,18 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ad_account_base')
-          #     field: account_id_stripped
+          - relationships:
+              to: ref('ad_account_base')
+              field: account_id_stripped
       - name: bid_amount
         description: ''
       - name: campaign_id
         description: ''
         tests:
           - not_null
-      #    - relationships:
-      #        to: ref('campaigns_base')
-      #        field: id
+          - relationships:
+              to: ref('campaigns_base')
+              field: id
       - name: created_time
         description: ''
       - name: source_ad_id
@@ -743,9 +743,9 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ads_base')
-          #     field: id
+          - relationships:
+              to: ref('ads_base')
+              field: id
       - name: date_start
         description: ''
       - name: date_stop
@@ -788,9 +788,9 @@ models:
         description: ''
         tests:
           - not_null
-          # - relationships:
-          #     to: ref('ad_account_base')
-          #     field: account_id_stripped
+          - relationships:
+              to: ref('ad_account_base')
+              field: account_id_stripped
       - name: adset_name
         description: ''
       - name: unique_ctr

--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -771,8 +771,10 @@ models:
           - relationships:
               to: ref('ads_base')
               field: id
+              # Depending on how airbyte is configured, we may have insights records for
+              # ads that are inactive/not in the ads table
               config:
-                where: "date_start > '2022-01-01'"
+                where: "date_start > '2022-01-01' and spend > 0"
       - name: date_start
         description: ''
       - name: date_stop

--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -439,6 +439,8 @@ models:
           - relationships:
               to: ref('ad_account_base')
               field: account_id_stripped
+              config:
+                where: "date_start > '2022-01-01'"
       - name: account_name
         description: ''
       - name: _airbyte_emitted_at
@@ -821,7 +823,7 @@ models:
               to: ref('ad_account_base')
               field: account_id_stripped
               config:
-                where: "created_time > '2022-01-01'"
+                where: "created_time > '2022-01-01' and spend > 0"
       - name: adset_name
         description: ''
       - name: unique_ctr

--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -776,7 +776,6 @@ models:
           - relationships:
               to: ref('ads_base')
               field: id
-              description:
               # There are a handful of edge cases where ads appear in the insights table
               # but not the ads table, likely as a result of how Airbyte handles date
               # filtering. We can safely ignore these cases.


### PR DESCRIPTION
These tests were hotfix disabled when deploying to prod, because there were failures on prod data that we didn't experience when running against dev.

There seem to have been some inconsistencies with how airbyte applied date filters across certain models, so there might be records in the `ads` table that don't have corresponding campaigns in the `campaigns` table. To handle this, I've filtered most of the tests on `created_time` to match the airbyte connection settings grabbing data from 2022 and beyond. There are a couple of insights tables that have stats generated for old ads/campaigns (all 0 spend, 0 impressions) and I've filtered those out too.