### PR TITLE
hotfix: remove schema from configs in USVote Foundation sync

### DIFF
--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_ab1.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_ab1.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_ab2.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_ab2.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to cast each column to its adequate SQL type converted from the JSON schema type

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_ab3.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_ab3.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to build a hash column based on the values of this record

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_ab1.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_ab1.sql
@@ -1,7 +1,6 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "_airbyte_usvote_foundation",
     tags = [ "nested-intermediate" ]
 ) }}
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_ab2.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_ab2.sql
@@ -1,7 +1,6 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "_airbyte_usvote_foundation",
     tags = [ "nested-intermediate" ]
 ) }}
 -- SQL model to cast each column to its adequate SQL type converted from the JSON schema type

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_ab3.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_ab3.sql
@@ -1,7 +1,6 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "_airbyte_usvote_foundation",
     tags = [ "nested-intermediate" ]
 ) }}
 -- SQL model to build a hash column based on the values of this record

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_contacts_ab1.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_contacts_ab1.sql
@@ -1,7 +1,6 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "_airbyte_usvote_foundation",
     tags = [ "nested-intermediate" ]
 ) }}
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_contacts_ab2.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_contacts_ab2.sql
@@ -1,7 +1,6 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "_airbyte_usvote_foundation",
     tags = [ "nested-intermediate" ]
 ) }}
 -- SQL model to cast each column to its adequate SQL type converted from the JSON schema type

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_contacts_ab3.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_contacts_ab3.sql
@@ -1,7 +1,6 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "_airbyte_usvote_foundation",
     tags = [ "nested-intermediate" ]
 ) }}
 -- SQL model to build a hash column based on the values of this record

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_officials_ab1.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_officials_ab1.sql
@@ -1,7 +1,6 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "_airbyte_usvote_foundation",
     tags = [ "nested-intermediate" ]
 ) }}
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_officials_ab2.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_officials_ab2.sql
@@ -1,7 +1,6 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "_airbyte_usvote_foundation",
     tags = [ "nested-intermediate" ]
 ) }}
 -- SQL model to cast each column to its adequate SQL type converted from the JSON schema type

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_officials_ab3.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_officials_ab3.sql
@@ -1,7 +1,6 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "_airbyte_usvote_foundation",
     tags = [ "nested-intermediate" ]
 ) }}
 -- SQL model to build a hash column based on the values of this record

--- a/dbt-cta/usvote_foundation/models/0_ctes/officials_ab1.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/officials_ab1.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema

--- a/dbt-cta/usvote_foundation/models/0_ctes/officials_ab2.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/officials_ab2.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to cast each column to its adequate SQL type converted from the JSON schema type

--- a/dbt-cta/usvote_foundation/models/0_ctes/officials_ab3.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/officials_ab3.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to build a hash column based on the values of this record

--- a/dbt-cta/usvote_foundation/models/0_ctes/regions_ab1.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/regions_ab1.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema

--- a/dbt-cta/usvote_foundation/models/0_ctes/regions_ab2.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/regions_ab2.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to cast each column to its adequate SQL type converted from the JSON schema type

--- a/dbt-cta/usvote_foundation/models/0_ctes/regions_ab3.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/regions_ab3.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to build a hash column based on the values of this record

--- a/dbt-cta/usvote_foundation/models/0_ctes/states_ab1.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/states_ab1.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema

--- a/dbt-cta/usvote_foundation/models/0_ctes/states_ab2.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/states_ab2.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to cast each column to its adequate SQL type converted from the JSON schema type

--- a/dbt-cta/usvote_foundation/models/0_ctes/states_ab3.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/states_ab3.sql
@@ -2,7 +2,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "_airbyte_usvote_foundation",
     tags = [ "top-level-intermediate" ]
 ) }}
 -- SQL model to build a hash column based on the values of this record

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_base.sql
@@ -6,7 +6,6 @@
     partitions=partitions_to_replace,
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "usvote_foundation",
     tags = [ "nested" ]
 ) }}
 -- Final base SQL model

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_contacts_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_contacts_base.sql
@@ -6,7 +6,6 @@
     partitions=partitions_to_replace,
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "usvote_foundation",
     tags = [ "nested" ]
 ) }}
 -- Final base SQL model

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_base.sql
@@ -7,7 +7,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "usvote_foundation",
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_officials_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_officials_base.sql
@@ -6,7 +6,6 @@
     partitions=partitions_to_replace,
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    schema = "usvote_foundation",
     tags = [ "nested" ]
 ) }}
 -- Final base SQL model

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/officials_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/officials_base.sql
@@ -7,7 +7,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "usvote_foundation",
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/regions_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/regions_base.sql
@@ -7,7 +7,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "usvote_foundation",
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/states_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/states_base.sql
@@ -7,7 +7,6 @@
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
     unique_key = '_airbyte_ab_id',
-    schema = "usvote_foundation",
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model


### PR DESCRIPTION
These should be specified in the config YAML read by daggy mcdagface, not specified within dbt. (The sync still delivers data successfully, but we want to use the same strat for all our syncs.)

cc @kanelouise - I think these get added in the Airbyte-generated dbt... I wonder if there's a way we can modify the init_dbt.sh script to remove the `schema = ...` lines? If not, then we will need to document somewhere that the person initializing the dbt for a new sync needs to make sure to remove these bits, since it's a very non-obvious step 🤔 