### PR TITLE
Fix: route all elementary data to CTA project [DE-200]

### DIFF
--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -10,6 +10,7 @@ packages-install-path: "dbt-packages"
 models:
   elementary:
     schema: "elementary"
+    database:  "{{ env_var('CTA_PROJECT_ID') }}"
   default:
     0_ctes:
       +tags: 
@@ -25,7 +26,7 @@ models:
       +materialized: incremental
       +incremental_strategy: insert_overwrite
       +on_schema_change: sync_all_columns
-      +full_refresh: false
+      # +full_refresh: false
     1_cta_tables:
       +tags:
         - cta

--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -26,7 +26,7 @@ models:
       +materialized: incremental
       +incremental_strategy: insert_overwrite
       +on_schema_change: sync_all_columns
-      # +full_refresh: false
+      +full_refresh: false
     1_cta_tables:
       +tags:
         - cta


### PR DESCRIPTION
We need to override where elementary is trying to write logs from each dbt run. We don't want to write to partner projects, so we add a `database:` param on all elementary models so that we always write to the CTA project.

Post-merge:
 - [ ] manually upload `dbt_project.yml` to DAGs folder, since I don't think the deploy works on that file