### PR TITLE
hotfix: (monitoring) add "skipped" as an allowable status type for int_group_by_invocation_status_type

### DIFF
--- a/dbt-cta/monitoring/models/1_intermediate/pipeline_health/_int_pipeline_health__models.yml
+++ b/dbt-cta/monitoring/models/1_intermediate/pipeline_health/_int_pipeline_health__models.yml
@@ -26,7 +26,7 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ["error","success","fail","warn","pass"]
+              values: ["error","success","fail","warn","pass","skipped"]
       - name: count
     tests:
       # test a unique comination of columns


### PR DESCRIPTION
cc @jackwelty, test was failing because "skipped" is a possible status type that we were not allowing 👀 I'm gonna yolo this in, but pls flag if this is in error