### PR TITLE
feat: add `message`, `compiled_code` to `int_group_by_invocation_status_type'

### DIFF
--- a/dbt-cta/monitoring/models/1_intermediate/pipeline_health/int_group_by_invocation_status_type.sql
+++ b/dbt-cta/monitoring/models/1_intermediate/pipeline_health/int_group_by_invocation_status_type.sql
@@ -21,7 +21,9 @@ with
             run.resource_type,
             run.status,
             run.failures,
-            run.rows_affected
+            run.rows_affected,
+            run.message,
+            run.compiled_code
 
         from filter_invocations as inv
         left join run_results run using (invocation_id)


### PR DESCRIPTION
I just think they're neat!

@jackwelty we should think of a way to surface run-level data in the pipeline health dash - something to give people insight into why models or tests failed, you know? I mean they can always query bigquery, but you know how it is 🤔 

(no need to act on this right now, I'll request this feature via a ticket!)