### PR TITLE
[DE-294] airbyte_ab_id is not always unique

### DIFF
--- a/utils/universal_tests.yml
+++ b/utils/universal_tests.yml
@@ -5,7 +5,6 @@
 columns:
   - name: _airbyte_ab_id
     tests:
-      - unique
       - not_null
   - name: _airbyte_normalized_at
     tests:


### PR DESCRIPTION
This pull request removes the "unique" test from the auto-applied "universal tests" in our schema generation script, since the `_airbyte_ab_id` column is not always unique.