### PR TITLE
[DE-296] POC of pipeline health metrics for non-dbt syncs

### DIFF
--- a/dbt-cta/monitoring/models/0_staging/composer_logs/_composer_logs__models.yml
+++ b/dbt-cta/monitoring/models/0_staging/composer_logs/_composer_logs__models.yml
@@ -1,0 +1,39 @@
+version: 2
+
+models:
+
+  - name: stg_composer_logs__scheduler
+    description: >
+      A staging model of the raw log sync data from the Composer Scheduler. A bunch of
+      these columns are wild nested fields that we don't really need.
+    columns:
+      - name: logName
+        tests:
+          - not_null
+      - name: resource
+      - name: textPayload
+        description: >
+          This is the raw log text field that we eventually want to parse.
+        tests:
+          - not_null
+      - name: log_timestamp
+      - name: received_timestamp
+      - name: severity
+      - name: insert_id
+        tests:
+          - not_null
+          - unique
+      - name: httpRequest
+      - name: labels
+      - name: operation
+      - name: trace
+      - name: spanId
+      - name: traceSampled
+      - name: sourceLocation
+      - name: split
+      - name: resource_type
+        tests:
+          - accepted_values:
+              values: ['cloud_composer_environment']
+      - name: project_id
+      - name: environment_name

--- a/dbt-cta/monitoring/models/0_staging/composer_logs/_composer_logs__sources.yml
+++ b/dbt-cta/monitoring/models/0_staging/composer_logs/_composer_logs__sources.yml
@@ -1,0 +1,31 @@
+version: 2
+sources:
+- name: composer_logs
+  database: "{{ env_var('CTA_PROJECT_ID') }}"
+  schema: monitoring
+  tables:
+    - name: airflow_scheduler
+      identifier: airflow_scheduler_*
+      description: >-
+        This table is created by a GCS "log sink" that is configured to export logs from
+        Composer to BigQuery. We filter to only logs from the Airflow Scheduler that
+        contain the text "DagRun Finished" in the textPayload.
+        
+        The dev sync is called `dev-airflow-dag-runs`
+      columns:
+        - name: logName
+        - name: resource
+        - name: textPayload
+        - name: timestamp
+        - name: receiveTimestamp
+        - name: severity
+        - name: insertId
+        - name: httpRequest
+        - name: labels
+        - name: operation
+        - name: trace
+        - name: spanId
+        - name: traceSampled
+        - name: sourceLocation
+        - name: split
+  

--- a/dbt-cta/monitoring/models/0_staging/composer_logs/stg_composer_logs__scheduler.sql
+++ b/dbt-cta/monitoring/models/0_staging/composer_logs/stg_composer_logs__scheduler.sql
@@ -1,22 +1,22 @@
-with source as (select * from {{ source("composer_logs", "airflow_scheduler") }})
+with
+    source as (select * from {{ source("composer_logs", "airflow_scheduler") }}),
+    unpack_nested_fields as (
+        select
+            *,
+            resource.type as resource_type,
+            resource.labels.project_id as project_id,
+            resource.labels.environment_name as environment_name
 
-, unpack_nested_fields as (
+        from source
+    ),
+    rename as (
+        select
+            * except (insertid, timestamp, receivetimestamp),
+            insertid as insert_id,
+            timestamp as log_timestamp,
+            receivetimestamp as received_timestamp
+        from unpack_nested_fields
+    )
+
 select *
-, resource.type as resource_type
-, resource.labels.project_id as project_id
-, resource.labels.environment_name as environment_name
-
-from source
-)
-
-, rename as (
-    select * except(insertId, timestamp, receiveTimestamp)
-    , insertId as insert_id
-    , timestamp as log_timestamp
-    , receiveTimestamp as received_timestamp
-    from unpack_nested_fields
-)
-
-select * from rename
-
-
+from rename

--- a/dbt-cta/monitoring/models/0_staging/composer_logs/stg_composer_logs__scheduler.sql
+++ b/dbt-cta/monitoring/models/0_staging/composer_logs/stg_composer_logs__scheduler.sql
@@ -1,0 +1,22 @@
+with source as (select * from {{ source("composer_logs", "airflow_scheduler") }})
+
+, unpack_nested_fields as (
+select *
+, resource.type as resource_type
+, resource.labels.project_id as project_id
+, resource.labels.environment_name as environment_name
+
+from source
+)
+
+, rename as (
+    select * except(insertId, timestamp, receiveTimestamp)
+    , insertId as insert_id
+    , timestamp as log_timestamp
+    , receiveTimestamp as received_timestamp
+    from unpack_nested_fields
+)
+
+select * from rename
+
+

--- a/dbt-cta/monitoring/models/1_intermediate/composer_logs/_int_composer_logs__models.yml
+++ b/dbt-cta/monitoring/models/1_intermediate/composer_logs/_int_composer_logs__models.yml
@@ -1,0 +1,39 @@
+version: 2
+
+models: 
+  - name: int_parse_scheduler_logs
+    description: >
+      This model takes the raw log sink table of all the "DAGrun Finished" logs from
+      Composer and parses out a bunch of relevent fields about the DAG run from the
+      text payload.
+    columns:
+      - name: insert_id
+        tests: 
+          - not_null
+          - unique
+      - name: log_timestamp
+      - name: received_timestamp
+      - name: project_id
+        tests: 
+          - not_null
+      - name: environment_name
+      - name: dag_id
+        tests: 
+          - not_null
+      - name: execution_date
+      - name: run_id
+        tests:
+          - not_null
+      - name: run_start_date
+      - name: run_end_date
+      - name: run_duration
+      - name: state
+        # TODO(Jack): add accepted values tests here
+      - name: external_trigger
+      - name: run_type
+      - name: data_interval_start
+      - name: data_interval_end
+      - name: dag_hash
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [dag_id, run_id]

--- a/dbt-cta/monitoring/models/1_intermediate/composer_logs/_int_composer_logs__models.yml
+++ b/dbt-cta/monitoring/models/1_intermediate/composer_logs/_int_composer_logs__models.yml
@@ -28,7 +28,9 @@ models:
       - name: run_end_date
       - name: run_duration
       - name: state
-        # TODO(Jack): add accepted values tests here
+        tests:
+          - accepted_values:
+              values: ['success', 'failed']
       - name: external_trigger
       - name: run_type
       - name: data_interval_start

--- a/dbt-cta/monitoring/models/1_intermediate/composer_logs/int_parse_scheduler_logs.sql
+++ b/dbt-cta/monitoring/models/1_intermediate/composer_logs/int_parse_scheduler_logs.sql
@@ -1,0 +1,82 @@
+with
+    source as (select * from {{ ref("stg_composer_logs__scheduler") }}),
+
+    split_log_data as (
+        select *, split(textpayload, 'DagRun Finished: ')[offset(1)] as log_data
+        from source
+    ),
+    
+    /* The textpayload column contains a comma-separated list of key-value pairs, i.e.:
+        dag_id=example_dag, execution_date=2020-01-01T00:00:00+00:00, run_id=manual__2020-01-01T00:00:00+00:00, ...
+    */
+    generate_struct as (
+        select
+            *,
+            array(
+                select
+                    struct(
+                        split(v, "=")[offset(0)] as key,
+                        split(v, "=")[offset(1)] as value
+                    )
+                from unnest(split(log_data, ', ')) as v
+            ) as log_values
+        from split_log_data
+    )
+
+    {% set fields = [
+    "dag_id",
+    "execution_date",
+    "run_id",
+    "run_start_date",
+    "run_end_date",
+    "run_duration",
+    "state",
+    "external_trigger",
+    "run_type",
+    "data_interval_start",
+    "data_interval_end",
+    "dag_hash",
+] %},
+
+    unpack_values as (
+        select
+            insert_id
+            , log_timestamp
+            , received_timestamp
+            , project_id
+            , environment_name
+
+            {% for field in fields %}
+            ,
+            (
+                select value from unnest(generate_struct.log_values) where key = '{{ field }}'
+            ) as {{ field }}
+            {% endfor %}
+        from generate_struct
+
+    )
+
+, cast_data_types as (
+select 
+            insert_id
+            , cast(log_timestamp as timestamp) as log_timestamp
+            , cast(received_timestamp as timestamp) as received_timestamp
+            , project_id
+            , environment_name
+            , dag_id
+            , cast(execution_date as timestamp) as execution_date
+            , run_id
+            , cast(run_start_date as timestamp) as run_start_date
+            , cast(run_end_date as timestamp) as run_end_date
+            , cast(run_duration as float64) as run_duration
+            , state
+            , external_trigger
+            , run_type
+            , cast(data_interval_start as timestamp) as data_interval_start
+            , cast(data_interval_end as timestamp) as data_interval_end
+            , dag_hash
+
+from unpack_values
+)
+
+select * from cast_data_types

--- a/dbt-cta/monitoring/models/1_intermediate/composer_logs/int_parse_scheduler_logs.sql
+++ b/dbt-cta/monitoring/models/1_intermediate/composer_logs/int_parse_scheduler_logs.sql
@@ -5,7 +5,7 @@ with
         select *, split(textpayload, 'DagRun Finished: ')[offset(1)] as log_data
         from source
     ),
-    
+
     /* The textpayload column contains a comma-separated list of key-value pairs, i.e.:
         dag_id=example_dag, execution_date=2020-01-01T00:00:00+00:00, run_id=manual__2020-01-01T00:00:00+00:00, ...
     */
@@ -40,43 +40,45 @@ with
 
     unpack_values as (
         select
-            insert_id
-            , log_timestamp
-            , received_timestamp
-            , project_id
-            , environment_name
+            insert_id,
+            log_timestamp,
+            received_timestamp,
+            project_id,
+            environment_name
 
             {% for field in fields %}
             ,
             (
-                select value from unnest(generate_struct.log_values) where key = '{{ field }}'
+                select value
+                from unnest(generate_struct.log_values)
+                where key = '{{ field }}'
             ) as {{ field }}
             {% endfor %}
         from generate_struct
 
+    ),
+    cast_data_types as (
+        select
+            insert_id,
+            cast(log_timestamp as timestamp) as log_timestamp,
+            cast(received_timestamp as timestamp) as received_timestamp,
+            project_id,
+            environment_name,
+            dag_id,
+            cast(execution_date as timestamp) as execution_date,
+            run_id,
+            cast(run_start_date as timestamp) as run_start_date,
+            cast(run_end_date as timestamp) as run_end_date,
+            cast(run_duration as float64) as run_duration,
+            state,
+            external_trigger,
+            run_type,
+            cast(data_interval_start as timestamp) as data_interval_start,
+            cast(data_interval_end as timestamp) as data_interval_end,
+            dag_hash
+
+        from unpack_values
     )
 
-, cast_data_types as (
-select 
-            insert_id
-            , cast(log_timestamp as timestamp) as log_timestamp
-            , cast(received_timestamp as timestamp) as received_timestamp
-            , project_id
-            , environment_name
-            , dag_id
-            , cast(execution_date as timestamp) as execution_date
-            , run_id
-            , cast(run_start_date as timestamp) as run_start_date
-            , cast(run_end_date as timestamp) as run_end_date
-            , cast(run_duration as float64) as run_duration
-            , state
-            , external_trigger
-            , run_type
-            , cast(data_interval_start as timestamp) as data_interval_start
-            , cast(data_interval_end as timestamp) as data_interval_end
-            , dag_hash
-
-from unpack_values
-)
-
-select * from cast_data_types
+select *
+from cast_data_types

--- a/dbt-cta/monitoring/models/1_intermediate/composer_logs/int_parse_scheduler_logs.sql
+++ b/dbt-cta/monitoring/models/1_intermediate/composer_logs/int_parse_scheduler_logs.sql
@@ -79,6 +79,13 @@ with
 
         from unpack_values
     )
+    , filter_unused_dag as (
+        select * from cast_data_types
+        where dag_id not in ('dbt_monitoring') 
+        -- nulls are not allowed and will be caught by a test, but I don't want them
+        -- to get filtered out here
+        or dag_id is null
+    )
 
 select *
-from cast_data_types
+from filter_unused_dag

--- a/dbt-cta/monitoring/models/1_intermediate/composer_logs/int_parse_scheduler_logs.sql
+++ b/dbt-cta/monitoring/models/1_intermediate/composer_logs/int_parse_scheduler_logs.sql
@@ -81,7 +81,7 @@ with
     )
     , filter_unused_dag as (
         select * from cast_data_types
-        where dag_id not in ('dbt_monitoring') 
+        where dag_id not in ('airflow_monitoring', 'dbt_monitoring') 
         -- nulls are not allowed and will be caught by a test, but I don't want them
         -- to get filtered out here
         or dag_id is null


### PR DESCRIPTION
This PR adds a set of dbt models in our `monitoring/` project to parse the output of a GCP Log Sink, configured to output a small subset of logs from Composer. The scope of this ticket just called for a POC implementing our absolute base-level metrics, so the result is an intermediate table (`monitoring.int_parse_scheduler_logs`).

In future tickets, we can combine this table with our existing elementary-based logging and any additional logging we need for other metrics into a set of comprehensive reporting tables.

Deployment steps:
- [x] Create a log sink narrowed to just prod, and point it at an equivalent dataset in our prod project