### PR TITLE
[DE-289] Add run-level messages

### DIFF
--- a/dbt-cta/monitoring/models/1_intermediate/pipeline_health/_int_pipeline_health__models.yml
+++ b/dbt-cta/monitoring/models/1_intermediate/pipeline_health/_int_pipeline_health__models.yml
@@ -24,6 +24,10 @@ models:
       - name: total_tests
       - name: model_errors
       - name: total_models
+      - name: error_message
+        description: >
+          A concatted string of all error messages surfaced by dbt (and collected by
+          elementary) for a given invocation.
       - name: most_recent_invocation_type
         description: >
           This is a calculated windowed field that tells us which row is the most recent
@@ -70,6 +74,10 @@ models:
       - name: model_errors
       - name: total_tests
       - name: total_models
+      - name: error_message
+        description: >
+          A concatted string of all error messages surfaced by dbt (and collected by
+          elementary) for a given invocation.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns: ["airflow_run_id","sync_name","partner_name"]

--- a/dbt-cta/monitoring/models/1_intermediate/pipeline_health/int_group_by_invocation.sql
+++ b/dbt-cta/monitoring/models/1_intermediate/pipeline_health/int_group_by_invocation.sql
@@ -66,7 +66,7 @@ with
             ) as total_tests,
             coalesce(
                 sum(case when resource_type = 'model' then 1 end), 0
-            ) as total_models,
+            ) as total_models
             , string_agg(error_message,'\n ') as error_message
         from join_run_results
         group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10

--- a/dbt-cta/monitoring/models/1_intermediate/pipeline_health/int_group_by_invocation.sql
+++ b/dbt-cta/monitoring/models/1_intermediate/pipeline_health/int_group_by_invocation.sql
@@ -24,7 +24,9 @@ with
             run.failures,
             run.rows_affected,
             run.message,
-            run.compiled_code
+            run.compiled_code,
+            case when run.status != 'success' then concat(run.name||': '||run.message)
+            else null end as error_message
 
         from filter_invocations as inv
         left join run_results run using (invocation_id)
@@ -64,7 +66,8 @@ with
             ) as total_tests,
             coalesce(
                 sum(case when resource_type = 'model' then 1 end), 0
-            ) as total_models
+            ) as total_models,
+            , string_agg(error_message,'\n ') as error_message
         from join_run_results
         group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 

--- a/dbt-cta/monitoring/models/1_intermediate/pipeline_health/int_group_by_run.sql
+++ b/dbt-cta/monitoring/models/1_intermediate/pipeline_health/int_group_by_run.sql
@@ -14,6 +14,7 @@ with
             coalesce(sum(case when most_recent_invocation_type = 1 then total_tests else null end),0) as total_tests,
             coalesce(sum(case when most_recent_invocation_type = 1 then model_errors else null end),0) as model_errors,
             coalesce(sum(case when most_recent_invocation_type = 1 then total_models else null end),0) as total_models,
+            string_agg(error_message, '\n') as error_message
         from source
         group by 1, 2, 3
     ),

--- a/dbt-cta/monitoring/models/1_intermediate/pipeline_health/int_merge_logs.sql
+++ b/dbt-cta/monitoring/models/1_intermediate/pipeline_health/int_merge_logs.sql
@@ -29,6 +29,7 @@ with
             null as num_rows_added,
             data_source_type,
             null as data_source,
+            null as error_message,
             'composer' as log_source
 
         from exclude_elementary_logs
@@ -50,6 +51,7 @@ with
             null as num_rows_added,
             null as data_source_type,
             null as data_source,
+            error_message as error_message,
             'elementary' as log_source
 
         from elementary_logs

--- a/dbt-cta/monitoring/models/2_reporting/pipeline_health/_rpt_pipeline_health__models.yml
+++ b/dbt-cta/monitoring/models/2_reporting/pipeline_health/_rpt_pipeline_health__models.yml
@@ -73,6 +73,7 @@ models:
       - name: model_errors
       - name: successful_models
       - name: total_models
+      - name: error_message
 
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/dbt-cta/monitoring/models/2_reporting/pipeline_health/rpt_pipeline_health.sql
+++ b/dbt-cta/monitoring/models/2_reporting/pipeline_health/rpt_pipeline_health.sql
@@ -80,7 +80,8 @@ with
             total_tests,
             model_errors,
             successful_models,
-            total_models
+            total_models,
+            error_message
 
         from add_run_time
     )


### PR DESCRIPTION
This PR creates an `error_message` field in our final reporting table, and surfaces that field in a new viz component on the "Run Listing" page of our PHD ([live in dev](https://lookerstudio.google.com/s/n5BG9nkK1Sg)).

Elementary gives us the dbt error log for every failed invocation, so we just `string_agg()` those together with the model name, and stick all of that in a long string `error_message` field. "Real" debugging should probably take place via Airflow (and we provide all the necessary DAG/run IDs) for this, but this is a quick way for users to get a glimpse at what went wrong for a given run.

