### PR TITLE
[DE-259] Change FB relationships test config to warn

### DIFF
--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -27,9 +27,7 @@ models:
               # but not the ads table, likely as a result of how Airbyte handles date
               # filtering. We can safely ignore these cases.
               config:
-                severity: error
-                error_if: ">10"
-                warn_if: ">0"
+                severity: warn
                 where: "created_time > '2022-01-01'"
       - name: date_start
         description: ''
@@ -781,9 +779,7 @@ models:
               # filtering. We can safely ignore these cases.
               config:
                 where: "date_start > '2022-01-01' and spend > 0"
-                severity: error
-                error_if: ">10"
-                warn_if: ">0"
+                severity: warn
       - name: date_start
         description: ''
       - name: date_stop


### PR DESCRIPTION
In order to get elementary to route "warn" and "error" tests to different channels, we need to change the `severity` param on a test to `warn`. This PR is not meant to be merged, but is just a POC for how we would do this.

One flag: tests with different thresholds for error/warning cannot be configured this way. If we _ever_ want a test to error, it must have `severity: error`, and therefore will get routed to our errors channel, not our warning channel. Elementary purports to be working on a fix for this, but I'm not sure there's a timeline.