### PR TITLE
[DE-183] Persist docs to BQ

### DIFF
--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -8,6 +8,9 @@ model-paths: ["{{ env_var('SYNC_NAME') }}/models"]
 packages-install-path: "dbt-packages"
 
 models:
+  +persist_docs:
+    relation: true
+    columns: true
   elementary:
     schema: "elementary"
     database:  "{{ env_var('CTA_PROJECT_ID') }}"


### PR DESCRIPTION
This little bit of config persists the docs from our `schema.yml` files to BigQuery as table and column descriptions. This [model description](https://github.com/community-tech-alliance/dbt-cta/blob/main/dbt-cta/monitoring/models/0_staging/composer_logs/_composer_logs__models.yml#L6) is added to the view details: 
<img width="959" alt="image" src="https://github.com/community-tech-alliance/dbt-cta/assets/51384930/5eb6724f-6472-4d5f-8a06-c4114e5622cc">

and this [column description](https://github.com/community-tech-alliance/dbt-cta/blob/main/dbt-cta/monitoring/models/0_staging/composer_logs/_composer_logs__models.yml#L15) is added to the "Description" field in the UI: 
<img width="957" alt="image" src="https://github.com/community-tech-alliance/dbt-cta/assets/51384930/d252af34-3589-469c-b87b-e439bac70a25">

So far I've only run this in the `monitoring` project, but descriptions should populate each time a new sync runs. 