### PR TITLE
feat: skip creating schema yamls for partner models [PAD-1799]

### DIFF
--- a/utils/generate_schema_yml.py
+++ b/utils/generate_schema_yml.py
@@ -124,7 +124,9 @@ def generate_schema_dict(directory_path):
     if model_directory[:1] in ["0", "1"]:
         target = "cta"
     elif model_directory[:1] in ["2", "3"]:
-        target = "partner"
+        #target = "partner"
+        print("dbt tests currently do not work for partner models, skipping.")
+        return
     else:
         target = None
 


### PR DESCRIPTION
@jitoquinto @kanelouise @royconst per the spooky mystery in [PAD-1799](https://techallies.atlassian.net/browse/PAD-1799), modifying this script to skip partner models for the time being. Will revisit later once we can look into using dbt 1.6.0 (scheduled for July release), which implements official support for materialized view models.

[PAD-1799]: https://techallies.atlassian.net/browse/PAD-1799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ