### PR TITLE
feat: include `_airbyte_emitted_at` in matviews generated from helper script

### DIFF
--- a/utils/dbt_format_utils.py
+++ b/utils/dbt_format_utils.py
@@ -363,7 +363,7 @@ def create_matview_dbt_files_from_base(base_tables_path, output_path):
                         outfile.write(f"from {{{{ source('cta','{table_name}') }}}}")
                     if write_to_file:
                         if not any(substring in line for substring in
-                                   ['_airbyte_emitted_at', '_airbyte_ab_id', '_airbyte_normalized_at']):
+                                   ['_airbyte_ab_id', '_airbyte_normalized_at']):
                             outfile.write(line)
 
 


### PR DESCRIPTION
This tiny modification to the helper function in dbt_format_utils.py makes it so that when you use it to generate matviews for a sync, it will include the field `_airbyte_emitted_at` (whereas previously that field was being excluded along with `_airbyte_ab_id` and `_airbyte_normalized_at`, which we still don't really care about).

`_airbyte_emitted_at` is an important field for us to include in partner materialized views because it enables the partner to see when each row of data was originally synced, which is a specific request we have received.

for viz @kanelouise @jitoquinto @royconst 