### PR TITLE
feat: enhance cta_dbt_helper.sh to take options when running generate_dbt_tests()

### DIFF
--- a/utils/cta_dbt_helper.sh
+++ b/utils/cta_dbt_helper.sh
@@ -131,7 +131,7 @@ generate_dbt_tests() {
         INPUT_DIR_NAME=$(gum input --prompt "Enter the name of the vendor to generate tests for: " --placeholder "(ex. actblue)")
         OPTION_UNIVERSAL_TESTS=$(gum input --prompt "Would you like to initialize these files using the default tests (see universal_tests.yml)? " --placeholder " (Y is recommended! Or leave blank to skip)")
         if [ "$OPTION_UNIVERSAL_TESTS" == "Y" ]; then
-            CLI_OPTIONS="--universal-tests"
+            CLI_OPTIONS="--universal-tests ../utils/universal_tests.yml"
         fi
 
         OPTION_MERGE=$(gum input --prompt "Are you merging into an existing schema yaml? " --placeholder " (Y or leave blank to skip)")

--- a/utils/cta_dbt_helper.sh
+++ b/utils/cta_dbt_helper.sh
@@ -129,29 +129,33 @@ generate_dbt_tests() {
     # Get target path for vendor directory
     while [ -z "$INPUT_DIR_NAME" ]; do
         INPUT_DIR_NAME=$(gum input --prompt "Enter the name of the vendor to generate tests for: " --placeholder "(ex. actblue)")
+        OPTION_UNIVERSAL_TESTS=$(gum input --prompt "Would you like to initialize these files using the default tests (see universal_tests.yml)? " --placeholder " (Y is recommended! Or leave blank to skip)")
+        if [ "$OPTION_UNIVERSAL_TESTS" == "Y" ]; then
+            CLI_OPTIONS="--universal-tests"
+        fi
+
         OPTION_MERGE=$(gum input --prompt "Are you merging into an existing schema yaml? " --placeholder " (Y or leave blank to skip)")
+        
         # Only ask about overwriting if user does not say they are merging. Just nicer that way
         if [ "$OPTION_MERGE" != "Y" ]; then
             OPTION_OVERWRITE=$(gum input --prompt "Are you overwriting an existing schema yaml? " --placeholder " (Y or leave blank to skip)")
         fi
+
         # Construct the python command based on options indicated by user
         if [ "$OPTION_MERGE" = "Y" ]; then
-            CLI_OPTION="--merge"
-            COMMAND="python $ROOT_PATH/utils/generate_schema_yml.py --sync-name $INPUT_DIR_NAME $CLI_OPTION"
+            CLI_OPTIONS="${CLI_OPTIONS} --merge"
         elif [ "$OPTION_OVERWRITE" = "Y" ]; then
-            CLI_OPTION="--overwrite"
-            COMMAND="python $ROOT_PATH/utils/generate_schema_yml.py --sync-name $INPUT_DIR_NAME $CLI_OPTION"
-        else
-            CLI_OPTION="(none)"
-            COMMAND="python $ROOT_PATH/utils/generate_schema_yml.py --sync-name $INPUT_DIR_NAME"
+            CLI_OPTIONS="${CLI_OPTIONS} --overwrite"
         fi
+        COMMAND="python $ROOT_PATH/utils/generate_schema_yml.py --sync-name $INPUT_DIR_NAME $CLI_OPTIONS"
+        
         if [[ $? != 0 ]]; then
             echo "Ctrl-C caught, exiting..."
             exit 1
         fi
     done
     gum confirm "Confirm the vendor name is correct: $INPUT_DIR_NAME" || exit 1
-    gum confirm "Confirm the selected runtime option is correct: $CLI_OPTION" || exit 1
+    gum confirm "Confirm the selected runtime option is correct: $CLI_OPTIONS" || exit 1
 
     cd $ROOT_PATH/dbt-cta/
     pipenv run $COMMAND

--- a/utils/cta_dbt_helper.sh
+++ b/utils/cta_dbt_helper.sh
@@ -137,10 +137,10 @@ generate_dbt_tests() {
         # Construct the python command based on options indicated by user
         if [ "$OPTION_MERGE" = "Y" ]; then
             CLI_OPTION="--merge"
-            COMMAND="python $ROOT_PATH/utils/generate_schema_yml.py --sync-name $INPUT_DIR_NAME --merge"
+            COMMAND="python $ROOT_PATH/utils/generate_schema_yml.py --sync-name $INPUT_DIR_NAME $CLI_OPTION"
         elif [ "$OPTION_OVERWRITE" = "Y" ]; then
             CLI_OPTION="--overwrite"
-            COMMAND="python $ROOT_PATH/utils/generate_schema_yml.py --sync-name $INPUT_DIR_NAME --overwrite"
+            COMMAND="python $ROOT_PATH/utils/generate_schema_yml.py --sync-name $INPUT_DIR_NAME $CLI_OPTION"
         else
             CLI_OPTION="(none)"
             COMMAND="python $ROOT_PATH/utils/generate_schema_yml.py --sync-name $INPUT_DIR_NAME"

--- a/utils/universal_tests.yml
+++ b/utils/universal_tests.yml
@@ -6,6 +6,7 @@ columns:
   - name: _airbyte_ab_id
     tests:
       - not_null
+      - unique
   - name: _airbyte_normalized_at
     tests:
       - dbt_expectations.expect_column_values_to_be_of_type:


### PR DESCRIPTION
Currently the dbt helper script runs generate_schema_yml.py with the `--merge` option assumed, which causes it to fail if there does not already exist a schema yaml.

This PR introduces a couple of user prompts that enable them to run the command with `--merge`, `--overwrite`, or without any options selected (as one does when generating the schema yamls for the first time). The user can additionally specify if the schema yaml should use the "universal tests" in universal_tests.yml.

cc @jitoquinto @royconst @kanelouise 