### PR TITLE
hotfix (FB marketing): add a CTE to dedupe hashids in ads_insights_platform_and_device

### DIFF
--- a/dbt-cta/facebook_marketing/models/0_ctes/ads_insights_platform_and_device_ab5.sql
+++ b/dbt-cta/facebook_marketing/models/0_ctes/ads_insights_platform_and_device_ab5.sql
@@ -1,0 +1,17 @@
+{{ config(
+    cluster_by = "_airbyte_emitted_at",
+    partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = '_airbyte_ads_insights_platform_and_device_hashid'
+) }}
+
+-- SQL model to get latest `date_updated` values for each sid
+-- depends_on: {{ ref('ads_insights_platform_and_device_ab4') }}
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_ads_insights_platform_and_device_hashid ORDER BY updated_time desc) as rownum 
+FROM {{ ref('ads_insights_platform_and_device_ab4') }}
+)
+where rownum=1

--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/ads_insights_platform_and_device_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/ads_insights_platform_and_device_base.sql
@@ -10,7 +10,7 @@
     unique_key = '_airbyte_ads_insights_platform_and_device_hashid'
 ) }}
 
--- depends_on: {{ ref('ads_insights_platform_and_device_ab4') }}
+-- depends_on: {{ ref('ads_insights_platform_and_device_ab5') }}
 SELECT
      _airbyte_ads_insights_platform_and_device_hashid
     ,_airbyte_emitted_at
@@ -102,7 +102,7 @@ SELECT
     ,landing_page_views
     ,shares
     ,conversion_values
-from {{ ref('ads_insights_platform_and_device_ab4') }}
+from {{ ref('ads_insights_platform_and_device_ab5') }}
 
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})


### PR DESCRIPTION
This PR adds a CTE to the models that build ads_insights_platform_and_device so that prior to creating the `_base` table, the `_hashid` values are deduped using only the rows with the most recent `updated_time` values.

We were already using this logic in `ads_insights_overall`, and for whatever reason it wasn't necessary in `ads_insights_platform_and_device` until now, specifically for only one of our partners. But it's clearly a reasonable step to take, and one that we might find we need to add for other models as well. (Of course we could proactively add these CTEs for all of the models, but for now I assume it's better to make the minimal fix and only mess with the rest of the code if this issue crops up elsewhere.)