### PR TITLE
hotfix (freshdesk): dedupe on `id` for tables `conversation` and `ticket`

### DIFF
--- a/dbt-cta/freshdesk/models/0_ctes/conversation_ab3.sql
+++ b/dbt-cta/freshdesk/models/0_ctes/conversation_ab3.sql
@@ -1,0 +1,17 @@
+{{ config(
+    cluster_by = "_airbyte_emitted_at",
+    partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = 'id'
+) }}
+
+-- SQL model to get latest `date_updated` values for each sid
+-- depends_on: {{ ref('conversation_ab2') }}
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('conversation_ab2') }}
+)
+where rownum=1

--- a/dbt-cta/freshdesk/models/0_ctes/ticket_ab3.sql
+++ b/dbt-cta/freshdesk/models/0_ctes/ticket_ab3.sql
@@ -1,0 +1,17 @@
+{{ config(
+    cluster_by = "_airbyte_emitted_at",
+    partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = 'id'
+) }}
+
+-- SQL model to get latest `date_updated` values for each sid
+-- depends_on: {{ ref('ticket_ab2') }}
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('ticket_ab2') }}
+)
+where rownum=1

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/conversation_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/conversation_base.sql
@@ -7,11 +7,11 @@
     partitions = partitions_to_replace,
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = '_airbyte_ab_id',
+    unique_key = 'id',
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('conversation_ab2') }}
+-- depends_on: {{ ref('conversation_ab3') }}
 select
     ticket_id,
     id,
@@ -33,7 +33,7 @@ select
     source_additional_info,
     _airbyte_ab_id,
     _airbyte_emitted_at,
-from {{ ref('conversation_ab2') }}
+from {{ ref('conversation_ab3') }}
 -- conversations from {{ source('cta', '_airbyte_raw_conversations') }}
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/ticket_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/ticket_base.sql
@@ -6,7 +6,7 @@
 {{ config(
     cluster_by = "_airbyte_emitted_at",
     partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = '_airbyte_ab_id',
+    unique_key = 'id',
     partitions = partitions_to_replace
 ) }}
 
@@ -115,7 +115,7 @@ select
     to_emails,
     _airbyte_ab_id,
     _airbyte_emitted_at
-from {{ ref("ticket_ab2") }}
+from {{ ref("ticket_ab3") }}
 -- ticket from {{ source('cta', '_airbyte_raw_tickets') }}
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})


### PR DESCRIPTION
dbt tests for `id` uniqueness have started failing for `conversation` and `ticket`. These appear to be unwanted dupes originating in the source data, so this PR introduces CTEs that dedupe using only the most recently emitted row for each `id`.