### PR TITLE
hotfix (facebook): dedupe by start_date and adset_id in ad_set_report_base

### DIFF
--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/ad_set_report_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/ad_set_report_base.sql
@@ -46,12 +46,7 @@ SELECT
     *,
     {{ dbt_utils.surrogate_key([
     'date_start',
-    'account_id',
-    'account_name',
-    'campaign_id',
-    'campaign_name',
     'adset_id',
-    'adset_name'
     ]) }} as _ad_set_report_hashid
     ,current_timestamp as _airbyte_normalized_at
 FROM aggregations

--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/ad_set_report_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/ad_set_report_base.sql
@@ -5,7 +5,18 @@
 ) }}
 
 -- depends_on: {{ ref('ads_insights_overall_base') }}
-with aggregations as (
+with most_recent_only as (
+SELECT * FROM 
+    (
+    SELECT 
+        *,
+        ROW_NUMBER() OVER (PARTITION BY adset_id, date_start ORDER BY _airbyte_emitted_at desc) as rownum 
+    FROM {{ ref('ads_insights_overall_base') }}
+    )
+where rownum=1
+),
+
+aggregations as (
 
 select
     date_start,
@@ -19,7 +30,7 @@ select
     sum(clicks) as clicks,
     sum(impressions) as impressions,
     sum(spend) as spend
-from  {{ ref('ads_insights_overall_base') }}
+from  most_recent_only
 GROUP BY
     date_start,
     account_id,


### PR DESCRIPTION
This is kind of a special snowflake model - it's an aggregation meant to be used in reporting, which we built into the dbt back when we thought we would be doing this more regularly. As such it doesn't stick to our usual structure of building everything in `0_ctes`, and instead has those CTEs in the 1_cta_incremental model definition itself.

Anyway I added a CTE to dedupe the data in this report on `date_start` and `adset_id`, and also updated the definition of the hashid. Hopefully this avoids duplicate rows in the future?

(dbt tests are passing when run locally, so once this is merged I'll rerun those tasks for the sync in Airflow)