### PR TITLE
fix for an issue with turf tables

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 requests = "*"
+chardet= "*"
 dbt-core = "*"
 dbt-bigquery = "==1.3.0b2"
 gcloud = "*"


### PR DESCRIPTION
Moved turf_levels_base.sql to full_refresh. 
Ran the dbt locally and everything was successful. 
I cleared the failed upstream tests on the dag and marked the run successful. All the tests then passed on the dag.
Incidentally it also fixed the permissions errors that we had a prog lead ticket open for.