### PR TITLE
feat: add tests for USVote Foundation sync [DE-221]

### DIFF
--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_ab4.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_ab4.sql
@@ -1,0 +1,18 @@
+{{ config(
+    cluster_by = "_airbyte_emitted_at",
+    partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = '_airbyte_offices_hashid'
+) }}
+
+-- SQL model to dedupe on the hashid field calculated in *_ab3
+-- (this step is included because the data source seems to include duplicate rows)
+-- depends_on: {{ ref('offices_ab3') }}
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_offices_hashid ORDER BY _airbyte_ab_id desc) as rownum 
+FROM {{ ref('offices_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_ab4.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_ab4.sql
@@ -1,0 +1,18 @@
+{{ config(
+    cluster_by = "_airbyte_emitted_at",
+    partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = '_airbyte_addresses_hashid'
+) }}
+
+-- SQL model to dedupe on the hashid field calculated in *_ab3
+-- (this step is included because the data source seems to include duplicate rows)
+-- depends_on: {{ ref('offices_addresses_ab3') }}
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_addresses_hashid ORDER BY _airbyte_ab_id desc) as rownum 
+FROM {{ ref('offices_addresses_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_contacts_ab4.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_addresses_contacts_ab4.sql
@@ -1,0 +1,18 @@
+{{ config(
+    cluster_by = "_airbyte_emitted_at",
+    partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = '_airbyte_contacts_hashid'
+) }}
+
+-- SQL model to dedupe on the hashid field calculated in *_ab3
+-- (this step is included because the data source seems to include duplicate rows)
+-- depends_on: {{ ref('offices_addresses_contacts_ab3') }}
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_contacts_hashid ORDER BY _airbyte_ab_id desc) as rownum 
+FROM {{ ref('offices_addresses_contacts_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/usvote_foundation/models/0_ctes/offices_officials_ab4.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/offices_officials_ab4.sql
@@ -1,0 +1,18 @@
+{{ config(
+    cluster_by = "_airbyte_emitted_at",
+    partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = '_airbyte_officials_hashid'
+) }}
+
+-- SQL model to dedupe on the hashid field calculated in *_ab3
+-- (this step is included because the data source seems to include duplicate rows)
+-- depends_on: {{ ref('offices_officials_ab3') }}
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_officials_hashid ORDER BY _airbyte_ab_id desc) as rownum 
+FROM {{ ref('offices_officials_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/usvote_foundation/models/0_ctes/officials_ab4.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/officials_ab4.sql
@@ -1,0 +1,18 @@
+{{ config(
+    cluster_by = "_airbyte_emitted_at",
+    partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = '_airbyte_officials_hashid'
+) }}
+
+-- SQL model to dedupe on the hashid field calculated in *_ab3
+-- (this step is included because the data source seems to include duplicate rows)
+-- depends_on: {{ ref('officials_ab3') }}
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_officials_hashid ORDER BY _airbyte_ab_id desc) as rownum 
+FROM {{ ref('officials_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/usvote_foundation/models/0_ctes/regions_ab4.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/regions_ab4.sql
@@ -1,0 +1,18 @@
+{{ config(
+    cluster_by = "_airbyte_emitted_at",
+    partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = '_airbyte_regions_hashid'
+) }}
+
+-- SQL model to dedupe on the hashid field calculated in *_ab3
+-- (this step is included because the data source seems to include duplicate rows)
+-- depends_on: {{ ref('regions_ab3') }}
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_regions_hashid ORDER BY _airbyte_ab_id desc) as rownum 
+FROM {{ ref('regions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/usvote_foundation/models/0_ctes/states_ab4.sql
+++ b/dbt-cta/usvote_foundation/models/0_ctes/states_ab4.sql
@@ -1,0 +1,18 @@
+{{ config(
+    cluster_by = "_airbyte_emitted_at",
+    partition_by = {"field": "_airbyte_emitted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = '_airbyte_states_hashid'
+) }}
+
+-- SQL model to dedupe on the hashid field calculated in *_ab3
+-- (this step is included because the data source seems to include duplicate rows)
+-- depends_on: {{ ref('states_ab3') }}
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_states_hashid ORDER BY _airbyte_ab_id desc) as rownum 
+FROM {{ ref('states_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/_1_cta_full_refresh__models.yml
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/_1_cta_full_refresh__models.yml
@@ -1,0 +1,343 @@
+version: 2
+
+models:
+
+  - name: offices_addresses_base
+    description: ''
+    columns:
+      - name: _airbyte_offices_hashid
+        description: ''
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: zip
+        description: ''
+      - name: city
+        description: ''
+      - name: zip4
+        description: ''
+      - name: state
+        description: ''
+      - name: street1
+        description: ''
+      - name: street2
+        description: ''
+      - name: website
+        description: ''
+      - name: contacts
+        description: ''
+      - name: functions
+        description: ''
+      - name: address_to
+        description: ''
+      - name: main_email
+        description: ''
+      - name: is_physical
+        description: ''
+      - name: resource_uri
+        description: ''
+      - name: is_regular_mail
+        description: ''
+      - name: main_fax_number
+        description: ''
+      - name: main_phone_number
+        description: ''
+      - name: primary_contact_uri
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_addresses_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: offices_addresses_contacts_base
+    description: ''
+    columns:
+      - name: _airbyte_addresses_hashid
+        description: ''
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: address_uri
+        description: ''
+      - name: official_uri
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_contacts_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: offices_officials_base
+    description: ''
+    columns:
+      - name: _airbyte_offices_hashid
+        description: ''
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: fax
+        description: ''
+      - name: email
+        description: ''
+      - name: phone
+        description: ''
+      - name: title
+        description: ''
+      - name: suffix
+        description: ''
+      - name: initial
+        description: ''
+      - name: last_name
+        description: ''
+      - name: first_name
+        description: ''
+      - name: office_uri
+        description: ''
+      - name: office_type
+        description: ''
+      - name: resource_uri
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_officials_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: regions_base
+    description: ''
+    columns:
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: state
+        description: ''
+      - name: county
+        description: ''
+      - name: state_abbr
+        description: ''
+      - name: state_name
+        description: ''
+      - name: county_name
+        description: ''
+      - name: region_name
+        description: ''
+      - name: municipality
+        description: ''
+      - name: resource_uri
+        description: ''
+      - name: municipality_name
+        description: ''
+      - name: municipality_type
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_regions_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: officials_base
+    description: ''
+    columns:
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: fax
+        description: ''
+      - name: email
+        description: ''
+      - name: phone
+        description: ''
+      - name: title
+        description: ''
+      - name: office
+        description: ''
+      - name: suffix
+        description: ''
+      - name: initial
+        description: ''
+      - name: last_name
+        description: ''
+      - name: first_name
+        description: ''
+      - name: office_name
+        description: ''
+      - name: office_type
+        description: ''
+      - name: resource_uri
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_officials_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: states_base
+    description: ''
+    columns:
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: abbr
+        description: ''
+      - name: name
+        description: ''
+      - name: resource_uri
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_states_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: offices_base
+    description: ''
+    columns:
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: type
+        description: ''
+      - name: geoid
+        description: ''
+      - name: hours
+        description: ''
+      - name: notes
+        description: ''
+      - name: region
+        description: ''
+      - name: status
+        description: ''
+      - name: updated
+        description: ''
+      - name: addresses
+        description: ''
+      - name: officials
+        description: ''
+      - name: resource_uri
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_offices_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_base.sql
@@ -9,7 +9,7 @@
     tags = [ "nested" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('offices_addresses_ab3') }}
+-- depends_on: {{ ref('offices_addresses_ab4') }}
 select
     _airbyte_offices_hashid,
     id,
@@ -34,7 +34,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_addresses_hashid
-from {{ ref('offices_addresses_ab3') }}
+from {{ ref('offices_addresses_ab4') }}
 -- addresses at offices/addresses from {{ ref('offices') }}
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_contacts_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_contacts_base.sql
@@ -9,7 +9,7 @@
     tags = [ "nested" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('offices_addresses_contacts_ab3') }}
+-- depends_on: {{ ref('offices_addresses_contacts_ab4') }}
 select
     _airbyte_addresses_hashid,
     id,
@@ -19,7 +19,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_contacts_hashid
-from {{ ref('offices_addresses_contacts_ab3') }}
+from {{ ref('offices_addresses_contacts_ab4') }}
 -- contacts at offices/addresses/contacts from {{ ref('offices_addresses') }}
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_base.sql
@@ -10,7 +10,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('offices_ab3') }}
+-- depends_on: {{ ref('offices_ab4') }}
 select
     id,
     type,
@@ -27,7 +27,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_offices_hashid
-from {{ ref('offices_ab3') }}
+from {{ ref('offices_ab4') }}
 -- offices from {{ source('cta', '_airbyte_raw_offices') }}
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_officials_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_officials_base.sql
@@ -9,7 +9,7 @@
     tags = [ "nested" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('offices_officials_ab3') }}
+-- depends_on: {{ ref('offices_officials_ab4') }}
 select
     _airbyte_offices_hashid,
     id,
@@ -28,7 +28,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_officials_hashid
-from {{ ref('offices_officials_ab3') }}
+from {{ ref('offices_officials_ab4') }}
 -- officials at offices/officials from {{ ref('offices') }}
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/officials_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/officials_base.sql
@@ -10,7 +10,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('officials_ab3') }}
+-- depends_on: {{ ref('officials_ab4') }}
 select
     id,
     fax,
@@ -29,7 +29,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_officials_hashid
-from {{ ref('officials_ab3') }}
+from {{ ref('officials_ab4') }}
 -- officials from {{ source('cta', '_airbyte_raw_officials') }}
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/regions_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/regions_base.sql
@@ -10,7 +10,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('regions_ab3') }}
+-- depends_on: {{ ref('regions_ab4') }}
 select
     id,
     state,
@@ -27,7 +27,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_regions_hashid
-from {{ ref('regions_ab3') }}
+from {{ ref('regions_ab4') }}
 -- regions from {{ source('cta', '_airbyte_raw_regions') }}
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/states_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/states_base.sql
@@ -10,7 +10,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('states_ab3') }}
+-- depends_on: {{ ref('states_ab4') }}
 select
     id,
     abbr,
@@ -20,7 +20,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_states_hashid
-from {{ ref('states_ab3') }}
+from {{ ref('states_ab4') }}
 -- states from {{ source('cta', '_airbyte_raw_states') }}
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_emitted_at, day) in ({{ partitions_to_replace | join(',') }})


### PR DESCRIPTION
While working on this, I discovered that some of the raw data ingested from the USVote Foundation API has duplicate rows at the source. To see for yourself:

```
SELECT
JSON_EXTRACT_SCALAR(_airbyte_data,'$.id') as id, count(1)
FROM `PROJECT.DATASET._airbyte_raw_regions`
group by 1 order by 2 desc
```

Then, using one of those ids that have 2 rows (yes this could be a single query with a CTE, I'm a busy woman)

```
SELECT
_airbyte_data
FROM `PROJECT.DATASET._airbyte_raw_regions`
where JSON_EXTRACT_SCALAR(_airbyte_data,'$.id')='VALUE'
```

If you run those queries you will see there are fully duplicated rows in the raw data itself. This doesn't seem to be true for all of the tables, but it seemed easiest to just add a step in `0_ctes` that would dedupe by taking only a single row for each value of `*_hashid`.

After making that change, all of the tests in `1_cta_full_refresh/_1_cta_full_refresh__models.yml` are passing for me when run locally.