### PR TITLE
[DE-467] feat: create dbt project for `bigquery_monitoring`

### DIFF
--- a/dbt-cta/bigquery_monitoring/README.md
+++ b/dbt-cta/bigquery_monitoring/README.md
@@ -1,0 +1,5 @@
+# BigQuery Monitoring
+
+## Source tables
+
+These views read from the table `cloudaudit_googleapis_com_data_access` in CTA's project, which captures logs from bigquery jobs.

--- a/dbt-cta/bigquery_monitoring/models/1_intermediate/distinct_job_names.sql
+++ b/dbt-cta/bigquery_monitoring/models/1_intermediate/distinct_job_names.sql
@@ -1,0 +1,7 @@
+select distinct
+    json_extract_scalar(
+      protopayload_auditlog.metadataJson,
+      "$.jobChange.job.jobName"
+    ) as jobName
+from
+  {{ ref('filtered_logs') }}

--- a/dbt-cta/bigquery_monitoring/models/1_intermediate/distinct_job_names.sql
+++ b/dbt-cta/bigquery_monitoring/models/1_intermediate/distinct_job_names.sql
@@ -1,7 +1,7 @@
 select distinct
     json_extract_scalar(
-      protopayload_auditlog.metadataJson,
-      "$.jobChange.job.jobName"
+        protopayload_auditlog.metadataJson,
+        "$.jobChange.job.jobName"
     ) as jobName
 from
-  {{ ref('filtered_logs') }}
+    {{ ref('filtered_logs') }}

--- a/dbt-cta/bigquery_monitoring/models/1_intermediate/filtered_logs.sql
+++ b/dbt-cta/bigquery_monitoring/models/1_intermediate/filtered_logs.sql
@@ -1,4 +1,4 @@
 select 1 as colname
--- *
---from {{ source('cta','cloudaudit_googleapis_com_data_access') }}
---where resource.labels.project_id = '{{ env_var("PARTNER_PROJECT_ID") }}'
+ *
+from {{ source('cta','cloudaudit_googleapis_com_data_access') }}
+where resource.labels.project_id = '{{ env_var("PARTNER_PROJECT_ID") }}'

--- a/dbt-cta/bigquery_monitoring/models/1_intermediate/filtered_logs.sql
+++ b/dbt-cta/bigquery_monitoring/models/1_intermediate/filtered_logs.sql
@@ -1,4 +1,3 @@
-select
- *
+select *
 from {{ source('cta','cloudaudit_googleapis_com_data_access') }}
 where resource.labels.project_id = '{{ env_var("PARTNER_PROJECT_ID") }}'

--- a/dbt-cta/bigquery_monitoring/models/1_intermediate/filtered_logs.sql
+++ b/dbt-cta/bigquery_monitoring/models/1_intermediate/filtered_logs.sql
@@ -1,0 +1,4 @@
+select 1 as colname
+-- *
+--from {{ source('cta','cloudaudit_googleapis_com_data_access') }}
+--where resource.labels.project_id = '{{ env_var("PARTNER_PROJECT_ID") }}'

--- a/dbt-cta/bigquery_monitoring/models/1_intermediate/filtered_logs.sql
+++ b/dbt-cta/bigquery_monitoring/models/1_intermediate/filtered_logs.sql
@@ -1,4 +1,4 @@
-select 1 as colname
+select
  *
 from {{ source('cta','cloudaudit_googleapis_com_data_access') }}
 where resource.labels.project_id = '{{ env_var("PARTNER_PROJECT_ID") }}'

--- a/dbt-cta/bigquery_monitoring/models/1_intermediate/json_extract_job_details.sql
+++ b/dbt-cta/bigquery_monitoring/models/1_intermediate/json_extract_job_details.sql
@@ -1,46 +1,47 @@
 select
-  resource.labels.project_id as projectId
-  ,protopayload_auditlog.authenticationInfo.principalEmail as principalEmail
-  ,protopayload_auditlog.requestMetadata.callerSuppliedUserAgent as userAgent
-  ,resource.type as resource_type
-  ,timestamp(json_extract_scalar(
-      protopayload_auditlog.metadataJson,
-      "$.jobChange.job.jobStats.createTime"
-  )) as createTime
-  ,json_extract_scalar(
-      protopayload_auditlog.metadataJson,
-      "$.jobChange.job.jobName"
-  ) as jobName
-  ,array_reverse(split(json_extract_scalar(
-      protopayload_auditlog.metadataJson,
-      "$.jobChange.job.jobName"
-  ),'/'))[OFFSET(0)] as jobId
-  ,json_extract_array(
-      protopayload_auditlog.metadataJson,
-      "$.jobChange.job.jobStats.queryStats.referencedTables"
-    ) as referencedTables
-  ,json_extract_scalar(
-      protopayload_auditlog.metadataJson,
-      "$.jobChange.job.jobConfig.queryConfig.query") as query
-  ,cast(
+    resource.labels.project_id as projectId,
+    protopayload_auditlog.authenticationInfo.principalEmail as principalEmail,
+    protopayload_auditlog.requestMetadata.callerSuppliedUserAgent as userAgent,
+    resource.type as resource_type,
+    cast(
+        json_extract_scalar(
+            protopayload_auditlog.metadataJson,
+            "$.jobChange.job.jobStats.queryStats.totalProcessedBytes"
+        ) as int64
+    ) as totalProcessedBytes,
+    cast(
+        json_extract_scalar(
+            protopayload_auditlog.metadataJson,
+            "$.jobChange.job.jobStats.queryStats.totalBilledBytes"
+        ) as int64
+    ) as totalBilledBytes,
+    cast((cast(json_extract_scalar(
+        protopayload_auditlog.metadataJson,
+        "$.jobChange.job.jobStats.queryStats.totalBilledBytes"
+    ) as int64) / 1000000000000) * 6.25 as numeric) as totalCostUSD,
+    timestamp(json_extract_scalar(
+        protopayload_auditlog.metadataJson,
+        "$.jobChange.job.jobStats.createTime"
+    )) as createTime,
     json_extract_scalar(
-      protopayload_auditlog.metadataJson,
-      "$.jobChange.job.jobStats.queryStats.totalProcessedBytes"
-    ) as int64
-  ) as totalProcessedBytes
-  ,cast(
+        protopayload_auditlog.metadataJson,
+        "$.jobChange.job.jobName"
+    ) as jobName,
+    array_reverse(split(json_extract_scalar(
+        protopayload_auditlog.metadataJson,
+        "$.jobChange.job.jobName"
+    ), "/"))[offset(0)] as jobId,
+    json_extract_array(
+        protopayload_auditlog.metadataJson,
+        "$.jobChange.job.jobStats.queryStats.referencedTables"
+    ) as referencedTables,
     json_extract_scalar(
-      protopayload_auditlog.metadataJson,
-      "$.jobChange.job.jobStats.queryStats.totalBilledBytes"
-    ) as int64
-  ) as totalBilledBytes
-  ,cast((cast(json_extract_scalar(
-      protopayload_auditlog.metadataJson,
-      "$.jobChange.job.jobStats.queryStats.totalBilledBytes"
-    ) as int64)/1000000000000)*6.25 as numeric) as totalCostUSD
-  ,json_extract_scalar(
-      protopayload_auditlog.metadataJson,
-      "$.jobChange.job.jobStats.totalSlotMs"
-  ) as totalSlotMs
+        protopayload_auditlog.metadataJson,
+        "$.jobChange.job.jobConfig.queryConfig.query"
+    ) as query,
+    json_extract_scalar(
+        protopayload_auditlog.metadataJson,
+        "$.jobChange.job.jobStats.totalSlotMs"
+    ) as totalSlotMs
 from
-  {{ ref('filtered_logs') }}
+    {{ ref('filtered_logs') }}

--- a/dbt-cta/bigquery_monitoring/models/1_intermediate/json_extract_job_details.sql
+++ b/dbt-cta/bigquery_monitoring/models/1_intermediate/json_extract_job_details.sql
@@ -1,0 +1,46 @@
+select
+  resource.labels.project_id as projectId
+  ,protopayload_auditlog.authenticationInfo.principalEmail as principalEmail
+  ,protopayload_auditlog.requestMetadata.callerSuppliedUserAgent as userAgent
+  ,resource.type as resource_type
+  ,timestamp(json_extract_scalar(
+      protopayload_auditlog.metadataJson,
+      "$.jobChange.job.jobStats.createTime"
+  )) as createTime
+  ,json_extract_scalar(
+      protopayload_auditlog.metadataJson,
+      "$.jobChange.job.jobName"
+  ) as jobName
+  ,array_reverse(split(json_extract_scalar(
+      protopayload_auditlog.metadataJson,
+      "$.jobChange.job.jobName"
+  ),'/'))[OFFSET(0)] as jobId
+  ,json_extract_array(
+      protopayload_auditlog.metadataJson,
+      "$.jobChange.job.jobStats.queryStats.referencedTables"
+    ) as referencedTables
+  ,json_extract_scalar(
+      protopayload_auditlog.metadataJson,
+      "$.jobChange.job.jobConfig.queryConfig.query") as query
+  ,cast(
+    json_extract_scalar(
+      protopayload_auditlog.metadataJson,
+      "$.jobChange.job.jobStats.queryStats.totalProcessedBytes"
+    ) as int64
+  ) as totalProcessedBytes
+  ,cast(
+    json_extract_scalar(
+      protopayload_auditlog.metadataJson,
+      "$.jobChange.job.jobStats.queryStats.totalBilledBytes"
+    ) as int64
+  ) as totalBilledBytes
+  ,cast((cast(json_extract_scalar(
+      protopayload_auditlog.metadataJson,
+      "$.jobChange.job.jobStats.queryStats.totalBilledBytes"
+    ) as int64)/1000000000000)*6.25 as numeric) as totalCostUSD
+  ,json_extract_scalar(
+      protopayload_auditlog.metadataJson,
+      "$.jobChange.job.jobStats.totalSlotMs"
+  ) as totalSlotMs
+from
+  {{ ref('filtered_logs') }}

--- a/dbt-cta/bigquery_monitoring/models/2_reporting/job_details.sql
+++ b/dbt-cta/bigquery_monitoring/models/2_reporting/job_details.sql
@@ -1,0 +1,6 @@
+SELECT jobs.*
+FROM {{ ref('json_extract_job_details') }} as jobs
+JOIN {{ ref('distinct_job_names') }} as distinct_jobs using(jobName)
+where
+  jobs.resource_type = 'bigquery_project'
+  and array_length(jobs.referencedTables)>0

--- a/dbt-cta/bigquery_monitoring/models/2_reporting/job_details.sql
+++ b/dbt-cta/bigquery_monitoring/models/2_reporting/job_details.sql
@@ -1,6 +1,6 @@
-SELECT jobs.*
-FROM {{ ref('json_extract_job_details') }} as jobs
-JOIN {{ ref('distinct_job_names') }} as distinct_jobs using(jobName)
+select jobs.*
+from {{ ref('json_extract_job_details') }} as jobs
+inner join {{ ref('distinct_job_names') }} using (jobName)
 where
-  jobs.resource_type = 'bigquery_project'
-  and array_length(jobs.referencedTables)>0
+    jobs.resource_type = 'bigquery_project'
+    and array_length(jobs.referencedTables) > 0

--- a/dbt-cta/bigquery_monitoring/models/2_reporting/jobs_with_unnested_tables.sql
+++ b/dbt-cta/bigquery_monitoring/models/2_reporting/jobs_with_unnested_tables.sql
@@ -1,15 +1,16 @@
 with job_details as (select * from {{ ref('job_details') }}),
+
 parsed as (
-SELECT 
-  *,
-  array_length(referencedTables) as totalReferencedTables,
-  REGEXP_EXTRACT(table_referenced, r'datasets/([^/]+)') AS datasetId,
-  REGEXP_EXTRACT(replace(table_referenced, '"', ''), r'tables/([^/]+)') AS tableId
-FROM job_details as t
-CROSS JOIN UNNEST(referencedTables) as table_referenced
+    select
+        *,
+        array_length(referencedTables) as totalReferencedTables,
+        regexp_extract(table_referenced, r'datasets/([^/]+)') as datasetId,
+        regexp_extract(replace(table_referenced, '"', ''), r'tables/([^/]+)') as tableId
+    from job_details
+    cross join unnest(referencedTables) as table_referenced
 )
- 
-SELECT
-*,
-concat(projectId,'.',datasetId,',',tableId) as full_ref
-FROM parsed
+
+select
+    *,
+    concat(projectId, '.', datasetId, ',', tableId) as full_ref
+from parsed

--- a/dbt-cta/bigquery_monitoring/models/2_reporting/jobs_with_unnested_tables.sql
+++ b/dbt-cta/bigquery_monitoring/models/2_reporting/jobs_with_unnested_tables.sql
@@ -1,0 +1,15 @@
+with job_details as (select * from {{ ref('job_details') }}),
+parsed as (
+SELECT 
+  *,
+  array_length(referencedTables) as totalReferencedTables,
+  REGEXP_EXTRACT(table_referenced, r'datasets/([^/]+)') AS datasetId,
+  REGEXP_EXTRACT(replace(table_referenced, '"', ''), r'tables/([^/]+)') AS tableId
+FROM job_details as t
+CROSS JOIN UNNEST(referencedTables) as table_referenced
+)
+ 
+SELECT
+*,
+concat(projectId,'.',datasetId,',',tableId) as full_ref
+FROM parsed

--- a/dbt-cta/bigquery_monitoring/models/sources.yml
+++ b/dbt-cta/bigquery_monitoring/models/sources.yml
@@ -1,0 +1,7 @@
+version: 2
+sources:
+- name: cta
+  database: "{{ env_var('CTA_PROJECT_ID') }}"
+  schema: "{{ env_var('CTA_DATASET_ID') }}"
+  tables:
+  - name: "cloudaudit_googleapis_com_data_access"

--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -60,7 +60,7 @@ models:
       +materialized: incremental
       +on_schema_change: sync_all_columns
 
-    # for the /monitoring project
+    # for the /bigquery_monitoring project (no other syncs use these models)
     0_staging:
       +tags:
         - partner # adding this tag so we can run /bigquery_monitoring from DMDF

--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -62,11 +62,26 @@ models:
 
     # for the /monitoring project
     0_staging:
+      +tags:
+        - monitoring
       +materialized: view
+      +grant_access_to:
+        - project: "{{ env_var('CTA_PROJECT_ID') }}"
+          dataset: "{{ env_var('CTA_DATASET_ID') }}"
     1_intermediate:
+      +tags:
+        - monitoring
       +materialized: view
+      +grant_access_to:
+        - project: "{{ env_var('CTA_PROJECT_ID') }}"
+          dataset: "{{ env_var('CTA_DATASET_ID') }}"
     2_reporting:
+      +tags:
+        - monitoring
       +materialized: view
+      +grant_access_to:
+        - project: "{{ env_var('CTA_PROJECT_ID') }}"
+          dataset: "{{ env_var('CTA_DATASET_ID') }}"
 
     # for testing
     0_ctes_dev:

--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -63,21 +63,21 @@ models:
     # for the /monitoring project
     0_staging:
       +tags:
-        - monitoring
+        - partner # adding this tag so we can run /bigquery_monitoring from DMDF
       +materialized: view
       +grant_access_to:
         - project: "{{ env_var('CTA_PROJECT_ID') }}"
           dataset: "{{ env_var('CTA_DATASET_ID') }}"
     1_intermediate:
       +tags:
-        - monitoring
+        - partner
       +materialized: view
       +grant_access_to:
         - project: "{{ env_var('CTA_PROJECT_ID') }}"
           dataset: "{{ env_var('CTA_DATASET_ID') }}"
     2_reporting:
       +tags:
-        - monitoring
+        - partner
       +materialized: view
       +grant_access_to:
         - project: "{{ env_var('CTA_PROJECT_ID') }}"


### PR DESCRIPTION
This will enable us to generate authorized views in partner projects that give them access to reporting views with handy information about queries run in their project. (See accompanying PR in airflow-dags that adds this project to the DMDF config [here](https://github.com/community-tech-alliance/airflow-dags/pull/402))