### PR TITLE
feat: create dbt tests for StackAdapt

### DIFF
--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/_1_cta_full_refresh__models.yml
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/_1_cta_full_refresh__models.yml
@@ -1,0 +1,625 @@
+version: 2
+
+models:
+
+  - name: conversion_trackers_base
+    description: ''
+    columns:
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: name
+        description: ''
+      - name: user_id
+        description: ''
+      - name: conv_type
+        description: ''
+      - name: post_time
+        description: ''
+      - name: count_type
+        description: ''
+      - name: description
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_conversion_trackers_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: campaigns_base
+    description: ''
+    columns:
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: name
+        description: ''
+      - name: state
+        description: ''
+      - name: budget
+        description: ''
+      - name: channel
+        description: ''
+      - name: use_dma
+        description: ''
+      - name: bid_type
+        description: ''
+      - name: day_part
+        description: ''
+      - name: end_date
+        description: ''
+      - name: timezone
+        description: ''
+      - name: daily_cap
+        description: ''
+      - name: start_date
+        description: ''
+      - name: created_at
+        description: ''
+      - name: ip_options
+        description: ''
+      - name: updated_at
+        description: ''
+      - name: pace_evenly
+        description: ''
+      - name: city_options
+        description: ''
+      - name: line_item_id
+        description: ''
+      - name: advertiser_id
+        description: ''
+      - name: campaign_type
+        description: ''
+      - name: domain_action
+        description: ''
+      - name: freq_cap_time
+        description: ''
+      - name: optimize_type
+        description: ''
+      - name: all_native_ads_ids
+        description: ''
+      - name: domain_options
+        description: ''
+      - name: freq_cap_limit
+        description: ''
+      - name: optimize_value
+        description: ''
+      - name: country_options
+        description: ''
+      - name: smart_targeting
+        description: ''
+      - name: weekday_budgets
+        description: ''
+      - name: weekday_enabled
+        description: ''
+      - name: bid_amount_total
+        description: ''
+      - name: category_options
+        description: ''
+      - name: language_options
+        description: ''
+      - name: us_state_options
+        description: ''
+      - name: weekday_percents
+        description: ''
+      - name: device_os_options
+        description: ''
+      - name: uk_county_options
+        description: ''
+      - name: conversion_tracker_ids
+        description: ''
+      - name: device_type_options
+        description: ''
+      - name: other_state_options
+        description: ''
+      - name: supply_type_options
+        description: ''
+      - name: custom_segments_list
+        description: ''
+      - name: third_party_segments
+        description: ''
+      - name: supply_source_options
+        description: ''
+      - name: allow_iframe_engagement
+        description: ''
+      - name: canada_province_options
+        description: ''
+      - name: connection_type_options
+        description: ''
+      - name: device_os_family_options
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_campaigns_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: native_ads_input_data_video_creatives_base
+    description: ''
+    columns:
+      - name: _airbyte_input_data_hashid
+        description: ''
+        tests:
+          - not_null
+      - name: width
+        description: ''
+      - name: height
+        description: ''
+      - name: s3_url
+        description: ''
+      - name: bitrate
+        description: ''
+      - name: duration
+        description: ''
+      - name: file_type
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_video_creatives_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: advertisers_base
+    description: ''
+    columns:
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: name
+        description: ''
+      - name: description
+        description: ''
+      - name: all_line_item_ids
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_advertisers_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: native_ads_base
+    description: ''
+    columns:
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: icon
+        description: ''
+      - name: name
+        description: ''
+      - name: state
+        description: ''
+      - name: channel
+        description: ''
+      - name: cta_text
+        description: ''
+      - name: brandname
+        description: ''
+      - name: click_url
+        description: ''
+      - name: utm_source
+        description: ''
+      - name: utm_medium
+        description: ''
+      - name: utm_campaign
+        description: ''
+      - name: utm_term
+        description: ''
+      - name: utm_content
+        description: ''
+      - name: creatives
+        description: ''
+      - name: created_at
+        description: ''
+      - name: input_data
+        description: ''
+      - name: updated_at
+        description: ''
+      - name: audit_status
+        description: ''
+      - name: vast_trackers
+        description: ''
+      - name: api_frameworks
+        description: ''
+      - name: imp_tracker_urls
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_native_ads_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: native_ads_input_data_audio_creatives_base
+    description: ''
+    columns:
+      - name: _airbyte_input_data_hashid
+        description: ''
+        tests:
+          - not_null
+      - name: width
+        description: ''
+      - name: height
+        description: ''
+      - name: s3_url
+        description: ''
+      - name: bitrate
+        description: ''
+      - name: duration
+        description: ''
+      - name: file_type
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_audio_creatives_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: native_ads_input_data_base
+    description: ''
+    columns:
+      - name: _airbyte_native_ads_hashid
+        description: ''
+        tests:
+          - not_null
+      - name: heading
+        description: ''
+      - name: tagline
+        description: ''
+      - name: vast_xml
+        description: ''
+      - name: landing_url
+        description: ''
+      - name: audio_creatives
+        description: ''
+      - name: video_creatives
+        description: ''
+      - name: display_js_creative
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_input_data_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: campaigns_day_part_base
+    description: ''
+    columns:
+      - name: _airbyte_campaigns_hashid
+        description: ''
+        tests:
+          - not_null
+      - name: enabled
+        description: ''
+      - name: end_hour
+        description: ''
+      - name: timezone
+        description: ''
+      - name: start_hour
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_day_part_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: native_ads_creatives_base
+    description: ''
+    columns:
+      - name: _airbyte_native_ads_hashid
+        description: ''
+        tests:
+          - not_null
+      - name: id
+        description: ''
+      - name: url
+        description: ''
+      - name: width
+        description: ''
+      - name: height
+        description: ''
+      - name: file_name
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_creatives_hashid
+        description: ''
+        tests:
+          - not_null
+
+  - name: native_ads_vast_trackers_base
+    description: ''
+    columns:
+      - name: _airbyte_native_ads_hashid
+        description: ''
+        tests:
+          - not_null
+      - name: url
+        description: ''
+      - name: event_type
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_vast_trackers_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: native_ads_icon_base
+    description: ''
+    columns:
+      - name: _airbyte_native_ads_hashid
+        description: ''
+        tests:
+          - not_null
+      - name: id
+        description: ''
+      - name: url
+        description: ''
+      - name: width
+        description: ''
+      - name: height
+        description: ''
+      - name: file_name
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_icon_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: native_ads_input_data_display_js_creative_base
+    description: ''
+    columns:
+      - name: _airbyte_input_data_hashid
+        description: ''
+        tests:
+          - not_null
+      - name: width
+        description: ''
+      - name: height
+        description: ''
+      - name: img_url
+        description: ''
+      - name: js_code
+        description: ''
+      - name: is_expandable
+        description: ''
+      - name: js_code_macro
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_display_js_creative_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: line_items_base
+    description: ''
+    columns:
+      - name: id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: name
+        description: ''
+      - name: state
+        description: ''
+      - name: budget
+        description: ''
+      - name: end_date
+        description: ''
+      - name: daily_cap
+        description: ''
+      - name: start_date
+        description: ''
+      - name: pace_evenly
+        description: ''
+      - name: revenue_type
+        description: ''
+      - name: advertiser_id
+        description: ''
+      - name: revenue_value
+        description: ''
+      - name: all_campaign_ids
+        description: ''
+      - name: black_list_options
+        description: ''
+      - name: purchase_order_number
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_line_items_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+

--- a/dbt-cta/stackadapt/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/stackadapt/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -124,6 +124,9 @@ models:
               column_type: timestamp
       - name: _airbyte_account_line_items_stats_hashid
         description: ''
+        tests:
+          - not_null
+          - unique
 
   - name: account_native_ads_stats_creatives_base
     description: ''

--- a/dbt-cta/stackadapt/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/stackadapt/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -1,0 +1,465 @@
+version: 2
+
+models:
+
+  - name: account_line_items_stats_base
+    description: ''
+    columns:
+      - name: ctr
+        description: ''
+      - name: cvr
+        description: ''
+      - name: imp
+        description: ''
+      - name: ltr
+        description: ''
+      - name: atos
+        description: ''
+      - name: conv
+        description: ''
+      - name: cost
+        description: ''
+      - name: date
+        description: ''
+      - name: ecpa
+        description: ''
+      - name: ecpc
+        description: ''
+      - name: ecpe
+        description: ''
+      - name: ecpm
+        description: ''
+      - name: ecpv
+        description: ''
+      - name: rcpc
+        description: ''
+      - name: rcpe
+        description: ''
+      - name: rcpm
+        description: ''
+      - name: roas
+        description: ''
+      - name: click
+        description: ''
+      - name: ecpcl
+        description: ''
+      - name: rcpcl
+        description: ''
+      - name: profit
+        description: ''
+      - name: s_conv
+        description: ''
+      - name: conv_ip
+        description: ''
+      - name: revenue
+        description: ''
+      - name: vcomp_0
+        description: ''
+      - name: conv_rev
+        description: ''
+      - name: vcomp_25
+        description: ''
+      - name: vcomp_50
+        description: ''
+      - name: vcomp_75
+        description: ''
+      - name: vcomp_95
+        description: ''
+      - name: line_item
+        description: ''
+      - name: page_time
+        description: ''
+      - name: uniq_conv
+        description: ''
+      - name: uniq_ecpa
+        description: ''
+      - name: atos_units
+        description: ''
+      - name: conv_click
+        description: ''
+      - name: page_start
+        description: ''
+      - name: reach
+        description: ''
+      - name: vcomp_rate
+        description: ''
+      - name: engage_rate
+        description: ''
+      - name: tp_cpc_cost
+        description: ''
+      - name: tp_cpm_cost
+        description: ''
+      - name: unique_conv
+        description: ''
+      - name: view_percent
+        description: ''
+      - name: page_time_15s
+        description: ''
+      - name: sub_advertiser
+        description: ''
+      - name: page_time_units
+        description: ''
+      - name: conv_imp_derived
+        description: ''
+      - name: conv_imp_time_avg
+        description: ''
+      - name: conv_click_time_avg
+        description: ''
+      - name: frequency
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_account_line_items_stats_hashid
+        description: ''
+
+  - name: account_native_ads_stats_creatives_base
+    description: ''
+    columns:
+      - name: _airbyte_account_native_ads_stats_hashid
+        description: ''
+      - name: url
+        description: ''
+      - name: size
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_creatives_hashid
+        description: ''
+        tests:
+          - not_null
+
+  - name: account_campaigns_stats_base
+    description: ''
+    columns:
+      - name: ctr
+        description: ''
+      - name: cvr
+        description: ''
+      - name: imp
+        description: ''
+      - name: ltr
+        description: ''
+      - name: atos
+        description: ''
+      - name: conv
+        description: ''
+      - name: cost
+        description: ''
+      - name: date
+        description: ''
+      - name: ecpa
+        description: ''
+      - name: ecpc
+        description: ''
+      - name: ecpe
+        description: ''
+      - name: ecpm
+        description: ''
+      - name: ecpv
+        description: ''
+      - name: rcpc
+        description: ''
+      - name: rcpe
+        description: ''
+      - name: rcpm
+        description: ''
+      - name: roas
+        description: ''
+      - name: click
+        description: ''
+      - name: ecpcl
+        description: ''
+      - name: rcpcl
+        description: ''
+      - name: profit
+        description: ''
+      - name: s_conv
+        description: ''
+      - name: channel
+        description: ''
+      - name: conv_ip
+        description: ''
+      - name: revenue
+        description: ''
+      - name: vcomp_0
+        description: ''
+      - name: campaign
+        description: ''
+      - name: end_date
+        description: ''
+      - name: vcomp_25
+        description: ''
+      - name: vcomp_50
+        description: ''
+      - name: vcomp_75
+        description: ''
+      - name: vcomp_95
+        description: ''
+      - name: line_item
+        description: ''
+      - name: page_time
+        description: ''
+      - name: atos_units
+        description: ''
+      - name: conv_click
+        description: ''
+      - name: page_start
+        description: ''
+      - name: start_date
+        description: ''
+      - name: reach
+        description: ''
+      - name: vcomp_rate
+        description: ''
+      - name: campaign_id
+        description: ''
+      - name: conv_cookie
+        description: ''
+      - name: tp_cpc_cost
+        description: ''
+      - name: tp_cpm_cost
+        description: ''
+      - name: unique_conv
+        description: ''
+      - name: line_item_id
+        description: ''
+      - name: view_percent
+        description: ''
+      - name: campaign_type
+        description: ''
+      - name: page_time_15s
+        description: ''
+      - name: sub_advertiser
+        description: ''
+      - name: page_time_units
+        description: ''
+      - name: conv_imp_derived
+        description: ''
+      - name: conv_imp_time_avg
+        description: ''
+      - name: sub_advertiser_id
+        description: ''
+      - name: conv_click_time_avg
+        description: ''
+      - name: campaign_custom_fields
+        description: ''
+      - name: frequency
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_account_campaigns_stats_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+
+  - name: account_native_ads_stats_base
+    description: ''
+    columns:
+      - name: ctr
+        description: ''
+      - name: cvr
+        description: ''
+      - name: imp
+        description: ''
+      - name: ltr
+        description: ''
+      - name: atos
+        description: ''
+      - name: conv
+        description: ''
+      - name: cost
+        description: ''
+      - name: date
+        description: ''
+      - name: ecpa
+        description: ''
+      - name: ecpc
+        description: ''
+      - name: ecpe
+        description: ''
+      - name: ecpm
+        description: ''
+      - name: ecpv
+        description: ''
+      - name: rcpc
+        description: ''
+      - name: rcpe
+        description: ''
+      - name: rcpm
+        description: ''
+      - name: roas
+        description: ''
+      - name: click
+        description: ''
+      - name: ecpcl
+        description: ''
+      - name: rcpcl
+        description: ''
+      - name: domain
+        description: ''
+      - name: ios_id
+        description: ''
+      - name: is_ios
+        description: ''
+      - name: profit
+        description: ''
+      - name: s_conv
+        description: ''
+      - name: channel
+        description: ''
+      - name: conv_ip
+        description: ''
+      - name: heading
+        description: ''
+      - name: revenue
+        description: ''
+      - name: tagline
+        description: ''
+      - name: vcomp_0
+        description: ''
+      - name: campaign
+        description: ''
+      - name: end_date
+        description: ''
+      - name: start_date
+        description: ''
+      - name: nativead
+        description: ''
+      - name: vcomp_25
+        description: ''
+      - name: vcomp_50
+        description: ''
+      - name: vcomp_75
+        description: ''
+      - name: vcomp_95
+        description: ''
+      - name: click_url
+        description: ''
+      - name: utm_source
+        description: ''
+      - name: utm_medium
+        description: ''
+      - name: utm_campaign
+        description: ''
+      - name: utm_term
+        description: ''
+      - name: utm_content
+        description: ''
+      - name: creatives
+        description: ''
+      - name: line_item
+        description: ''
+      - name: page_time
+        description: ''
+      - name: uniq_conv
+        description: ''
+      - name: atos_units
+        description: ''
+      - name: conv_click
+        description: ''
+      - name: is_android
+        description: ''
+      - name: page_start
+        description: ''
+      - name: reach
+        description: ''
+      - name: vcomp_rate
+        description: ''
+      - name: campaign_id
+        description: ''
+      - name: engage_rate
+        description: ''
+      - name: full_domain
+        description: ''
+      - name: tp_cpc_cost
+        description: ''
+      - name: tp_cpm_cost
+        description: ''
+      - name: unique_conv
+        description: ''
+      - name: line_item_id
+        description: ''
+      - name: native_ad_id
+        description: ''
+      - name: view_percent
+        description: ''
+      - name: campaign_type
+        description: ''
+      - name: page_time_15s
+        description: ''
+      - name: native_ad_type
+        description: ''
+      - name: sub_advertiser
+        description: ''
+      - name: page_time_units
+        description: ''
+      - name: conv_imp_derived
+        description: ''
+      - name: conv_imp_time_avg
+        description: ''
+      - name: sub_advertiser_id
+        description: ''
+      - name: conv_click_time_avg
+        description: ''
+      - name: frequency
+        description: ''
+      - name: _airbyte_ab_id
+        description: ''
+        tests:
+          - not_null
+          - unique
+      - name: _airbyte_emitted_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_normalized_at
+        description: ''
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp
+      - name: _airbyte_account_native_ads_stats_hashid
+        description: ''
+        tests:
+          - not_null
+          - unique
+


### PR DESCRIPTION
Some of these tables are nested so do not have `unique` tests for `id` or `_airbyte_ab_id` or some `*_hashid` values. I just set these up so that everything passes when run on VFP's data in prod.

@jitoquinto @kanelouise @royconst could I possibly get 👀 on this somewhat soon so I can merge this in? It's a prerequisite for migrating our prod syncs to k8s airbyte.