### PR TITLE
fix: remove uniqueness checks for nested tables on airbyte_ab_id

### DIFF
--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/_1_cta_full_refresh__models.yml
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/_1_cta_full_refresh__models.yml
@@ -50,7 +50,6 @@ models:
         description: ''
         tests:
           - not_null
-          - unique
       - name: _airbyte_emitted_at
         description: ''
         tests:
@@ -85,7 +84,6 @@ models:
         description: ''
         tests:
           - not_null
-          - unique
       - name: _airbyte_emitted_at
         description: ''
         tests:
@@ -138,7 +136,6 @@ models:
         description: ''
         tests:
           - not_null
-          - unique
       - name: _airbyte_emitted_at
         description: ''
         tests:


### PR DESCRIPTION
Since these are tables that were created from nested fields, the `_airbyte_ab_id` is not unique. Removing that check so tests can succeed.