### PR TITLE
fix (hustle): typo in groups_base [DE-517]

### DIFF
--- a/dbt-cta/hustle/models/1_cta_incremental/groups_base.sql
+++ b/dbt-cta/hustle/models/1_cta_incremental/groups_base.sql
@@ -8,6 +8,6 @@
 -- Final base SQL model
             
 SELECT * EXCEPT (rownum)
-FROM {{ ref('goals_cte2') }}
+FROM {{ ref('groups_cte2') }}
     
     


### PR DESCRIPTION
major "ope" moment. This PR fixes a bug that was causing us to deliver `goals` data into the `groups` for the Hustle sync. Gonna yolo-merge to resolve DE-517