### PR TITLE
feat (spoke_mo): dedupe by id in ctes

### DIFF
--- a/dbt-cta/spoke_mo/models/0_ctes/assignment_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/assignment_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('assignment_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/assignment_feedback_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/assignment_feedback_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('assignment_feedback_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/campaign_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/campaign_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('campaign_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/campaign_admin_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/campaign_admin_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('campaign_admin_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/campaign_contact_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/campaign_contact_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('campaign_contact_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/canned_response_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/canned_response_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('canned_response_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/interaction_step_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/interaction_step_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('interaction_step_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/invite_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/invite_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('invite_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/job_request_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/job_request_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('job_request_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/knex_migrations_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/knex_migrations_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('knex_migrations_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/knex_migrations_lock_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/knex_migrations_lock_ab4.sql
@@ -4,7 +4,7 @@ SELECT * FROM
 (
 SELECT 
     *,
-    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_knex_migrations_lock_hashid ORDER BY _airbyte_emitted_at desc) as rownum 
 FROM {{ ref('knex_migrations_lock_ab3') }}
 )
 where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/knex_migrations_lock_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/knex_migrations_lock_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('knex_migrations_lock_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/log_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/log_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('log_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/message_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/message_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('message_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/opt_out_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/opt_out_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('opt_out_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/organization_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/organization_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('organization_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/organization_contact_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/organization_contact_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('organization_contact_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/owned_phone_number_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/owned_phone_number_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('owned_phone_number_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/pending_message_part_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/pending_message_part_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('pending_message_part_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/question_response_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/question_response_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('question_response_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/tag_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/tag_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('tag_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/tag_campaign_contact_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/tag_campaign_contact_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('tag_campaign_contact_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/tag_canned_response_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/tag_canned_response_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('tag_canned_response_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/user_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/user_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('user_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/user_cell_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/user_cell_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('user_cell_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/0_ctes/user_organization_ab4.sql
+++ b/dbt-cta/spoke_mo/models/0_ctes/user_organization_ab4.sql
@@ -1,0 +1,10 @@
+-- ensures the base model contains only one row per id
+
+SELECT * FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _airbyte_emitted_at desc) as rownum 
+FROM {{ ref('user_organization_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/assignment_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/assignment_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('assignment_ab3') }}
+-- depends_on: {{ ref('assignment_ab4') }}
 select
     max_contacts,
     user_id,
@@ -19,6 +19,6 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_assignment_hashid
-from {{ ref('assignment_ab3') }}
+from {{ ref('assignment_ab4') }}
 -- assignment from {{ source('cta', '_airbyte_raw_assignment') }}
 where 1=1

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/assignment_feedback_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/assignment_feedback_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('assignment_feedback_ab3') }}
+-- depends_on: {{ ref('assignment_feedback_ab4') }}
 select
     feedback,
     assignment_id,
@@ -21,7 +21,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_assignment_feedback_hashid
-from {{ ref('assignment_feedback_ab3') }}
+from {{ ref('assignment_feedback_ab4') }}
 -- assignment_feedback from {{ source('cta', '_airbyte_raw_assignment_feedback') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/campaign_admin_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/campaign_admin_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('campaign_admin_ab3') }}
+-- depends_on: {{ ref('campaign_admin_ab4') }}
 select
     ingest_method,
     ingest_data_reference,
@@ -25,7 +25,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_campaign_admin_hashid
-from {{ ref('campaign_admin_ab3') }}
+from {{ ref('campaign_admin_ab4') }}
 -- campaign_admin from {{ source('cta', '_airbyte_raw_campaign_admin') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/campaign_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/campaign_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('campaign_ab3') }}
+-- depends_on: {{ ref('campaign_ab4') }}
 select
     override_organization_texting_hours,
     batch_size,
@@ -38,7 +38,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_campaign_hashid
-from {{ ref('campaign_ab3') }}
+from {{ ref('campaign_ab4') }}
 -- campaign from {{ source('cta', '_airbyte_raw_campaign') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/campaign_contact_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/campaign_contact_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('campaign_contact_ab3') }}
+-- depends_on: {{ ref('campaign_contact_ab4') }}
 select
     zip,
     custom_fields,
@@ -29,7 +29,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_campaign_contact_hashid
-from {{ ref('campaign_contact_ab3') }}
+from {{ ref('campaign_contact_ab4') }}
 -- campaign_contact from {{ source('cta', '_airbyte_raw_campaign_contact') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/canned_response_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/canned_response_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('canned_response_ab3') }}
+-- depends_on: {{ ref('canned_response_ab4') }}
 select
     answer_actions_data,
     user_id,
@@ -22,7 +22,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_canned_response_hashid
-from {{ ref('canned_response_ab3') }}
+from {{ ref('canned_response_ab4') }}
 -- canned_response from {{ source('cta', '_airbyte_raw_canned_response') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/interaction_step_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/interaction_step_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('interaction_step_ab3') }}
+-- depends_on: {{ ref('interaction_step_ab4') }}
 select
     answer_actions_data,
     is_deleted,
@@ -24,7 +24,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_interaction_step_hashid
-from {{ ref('interaction_step_ab3') }}
+from {{ ref('interaction_step_ab4') }}
 -- interaction_step from {{ source('cta', '_airbyte_raw_interaction_step') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/invite_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/invite_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('invite_ab3') }}
+-- depends_on: {{ ref('invite_ab4') }}
 select
     is_valid,
     created_at,
@@ -18,7 +18,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_invite_hashid
-from {{ ref('invite_ab3') }}
+from {{ ref('invite_ab4') }}
 -- invite from {{ source('cta', '_airbyte_raw_invite') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/job_request_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/job_request_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('job_request_ab3') }}
+-- depends_on: {{ ref('job_request_ab4') }}
 select
     job_type,
     queue_name,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_job_request_hashid
-from {{ ref('job_request_ab3') }}
+from {{ ref('job_request_ab4') }}
 -- job_request from {{ source('cta', '_airbyte_raw_job_request') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/knex_migrations_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/knex_migrations_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('knex_migrations_ab3') }}
+-- depends_on: {{ ref('knex_migrations_ab4') }}
 select
     migration_time,
     name,
@@ -18,7 +18,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_knex_migrations_hashid
-from {{ ref('knex_migrations_ab3') }}
+from {{ ref('knex_migrations_ab4') }}
 -- knex_migrations from {{ source('cta', '_airbyte_raw_knex_migrations') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/knex_migrations_lock_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/knex_migrations_lock_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('knex_migrations_lock_ab3') }}
+-- depends_on: {{ ref('knex_migrations_lock_ab4') }}
 select
     is_locked,
     index,
@@ -16,7 +16,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_knex_migrations_lock_hashid
-from {{ ref('knex_migrations_lock_ab3') }}
+from {{ ref('knex_migrations_lock_ab4') }}
 -- knex_migrations_lock from {{ source('cta', '_airbyte_raw_knex_migrations_lock') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/log_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/log_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('log_ab3') }}
+-- depends_on: {{ ref('log_ab4') }}
 select
     from_num,
     to_num,
@@ -21,7 +21,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_log_hashid
-from {{ ref('log_ab3') }}
+from {{ ref('log_ab4') }}
 -- log from {{ source('cta', '_airbyte_raw_log') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/message_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/message_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('message_ab3') }}
+-- depends_on: {{ ref('message_ab4') }}
 select
     is_from_contact,
     campaign_contact_id,
@@ -33,7 +33,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_message_hashid
-from {{ ref('message_ab3') }}
+from {{ ref('message_ab4') }}
 -- message from {{ source('cta', '_airbyte_raw_message') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/opt_out_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/opt_out_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('opt_out_ab3') }}
+-- depends_on: {{ ref('opt_out_ab4') }}
 select
     reason_code,
     assignment_id,
@@ -20,7 +20,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_opt_out_hashid
-from {{ ref('opt_out_ab3') }}
+from {{ ref('opt_out_ab4') }}
 -- opt_out from {{ source('cta', '_airbyte_raw_opt_out') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/organization_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/organization_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('organization_ab3') }}
+-- depends_on: {{ ref('organization_ab4') }}
 select
     features,
     texting_hours_start,
@@ -22,7 +22,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_organization_hashid
-from {{ ref('organization_ab3') }}
+from {{ ref('organization_ab4') }}
 -- organization from {{ source('cta', '_airbyte_raw_organization') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/organization_contact_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/organization_contact_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('organization_contact_ab3') }}
+-- depends_on: {{ ref('organization_contact_ab4') }}
 select
     carrier,
     last_lookup,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_organization_contact_hashid
-from {{ ref('organization_contact_ab3') }}
+from {{ ref('organization_contact_ab4') }}
 -- organization_contact from {{ source('cta', '_airbyte_raw_organization_contact') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/owned_phone_number_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/owned_phone_number_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('owned_phone_number_ab3') }}
+-- depends_on: {{ ref('owned_phone_number_ab4') }}
 select
     service,
     allocated_to_id,
@@ -24,7 +24,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_owned_phone_number_hashid
-from {{ ref('owned_phone_number_ab3') }}
+from {{ ref('owned_phone_number_ab4') }}
 -- owned_phone_number from {{ source('cta', '_airbyte_raw_owned_phone_number') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/pending_message_part_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/pending_message_part_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('pending_message_part_ab3') }}
+-- depends_on: {{ ref('pending_message_part_ab4') }}
 select
     service,
     parent_id,
@@ -22,7 +22,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_pending_message_part_hashid
-from {{ ref('pending_message_part_ab3') }}
+from {{ ref('pending_message_part_ab4') }}
 -- pending_message_part from {{ source('cta', '_airbyte_raw_pending_message_part') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/question_response_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/question_response_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('question_response_ab3') }}
+-- depends_on: {{ ref('question_response_ab4') }}
 select
     campaign_contact_id,
     created_at,
@@ -19,7 +19,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_question_response_hashid
-from {{ ref('question_response_ab3') }}
+from {{ ref('question_response_ab4') }}
 -- question_response from {{ source('cta', '_airbyte_raw_question_response') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/tag_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/tag_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('tag_ab3') }}
+-- depends_on: {{ ref('tag_ab4') }}
 select
     is_deleted,
     updated_at,
@@ -22,7 +22,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_tag_hashid
-from {{ ref('tag_ab3') }}
+from {{ ref('tag_ab4') }}
 -- tag from {{ source('cta', '_airbyte_raw_tag') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/tag_campaign_contact_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/tag_campaign_contact_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('tag_campaign_contact_ab3') }}
+-- depends_on: {{ ref('tag_campaign_contact_ab4') }}
 select
     campaign_contact_id,
     updated_at,
@@ -20,7 +20,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_tag_campaign_contact_hashid
-from {{ ref('tag_campaign_contact_ab3') }}
+from {{ ref('tag_campaign_contact_ab4') }}
 -- tag_campaign_contact from {{ source('cta', '_airbyte_raw_tag_campaign_contact') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/tag_canned_response_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/tag_canned_response_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('tag_canned_response_ab3') }}
+-- depends_on: {{ ref('tag_canned_response_ab4') }}
 select
     canned_response_id,
     tag_id,
@@ -18,7 +18,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_tag_canned_response_hashid
-from {{ ref('tag_canned_response_ab3') }}
+from {{ ref('tag_canned_response_ab4') }}
 -- tag_canned_response from {{ source('cta', '_airbyte_raw_tag_canned_response') }}
 
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/user_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/user_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('user_ab3') }}
+-- depends_on: {{ ref('user_ab4') }}
 select
     terms,
     extra,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_hashid
-from {{ ref('user_ab3') }}
+from {{ ref('user_ab4') }}
 -- user from {{ source('cta', '_airbyte_raw_user') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/user_cell_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/user_cell_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('user_cell_ab3') }}
+-- depends_on: {{ ref('user_cell_ab4') }}
 select
     is_primary,
     user_id,
@@ -19,7 +19,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_cell_hashid
-from {{ ref('user_cell_ab3') }}
+from {{ ref('user_cell_ab4') }}
 -- user_cell from {{ source('cta', '_airbyte_raw_user_cell') }}
 where 1=1
 

--- a/dbt-cta/spoke_mo/models/1_cta_incremental/user_organization_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_incremental/user_organization_base.sql
@@ -8,7 +8,7 @@
     tags = [ "top-level" ]
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('user_organization_ab3') }}
+-- depends_on: {{ ref('user_organization_ab4') }}
 select
     role,
     user_id,
@@ -18,7 +18,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_organization_hashid
-from {{ ref('user_organization_ab3') }}
+from {{ ref('user_organization_ab4') }}
 -- user_organization from {{ source('cta', '_airbyte_raw_user_organization') }}
 where 1=1
 


### PR DESCRIPTION
This succeeded when run locally. Should prevent dupe rows in the future if Airbyte CDC doesn't work as intended, resulting in dupe rows in the raw data.