### PR TITLE
use `jsonpath="{.status.phase}"` to get status of pod

### DIFF
--- a/utils/copy_dbt_from_k8s_pod.sh
+++ b/utils/copy_dbt_from_k8s_pod.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+shopt -s nocasematch
+
 # Ensure the user provides a pod name regex pattern, namespace, and container name as arguments
 if [ "$#" -ne 3 ]; then
     echo "Usage: $0 <POD_NAME_REGEX_PATTERN> <NAMESPACE> <CONTAINER_NAME>"
@@ -18,7 +20,7 @@ while true; do
         # Use grep to filter pods based on the regex pattern
         if [[ $POD =~ $POD_NAME_PATTERN ]]; then
             # Fetch the container status using kubectl for each matching pod
-            CONTAINER_STATUS=$(kubectl get pod $POD -n $NAMESPACE -o=jsonpath="{.status.containerStatuses[?(@.name=='$CONTAINER_NAME')].state}")
+            CONTAINER_STATUS=$(kubectl get pod $POD -n $NAMESPACE -o=jsonpath="{.status.phase}")
 
             # Check if the container is Running
             if [[ "$CONTAINER_STATUS" == *'running'* ]]; then


### PR DESCRIPTION
@michaelefisher I was trying to use copy_dbt_from_k8s_pod.sh (I have my reasons) and this seems like a more straightforward way to check for whether a pod is in a Running state. (Also the code as currently written doesn't work for me - I can't use the existing jsonpath to access the status of a pod, even when I run the command manually in terminal)

However even after fixing(?) this part, I'm still not able to find any dbt files in the running pods. Here's what happens when I run the shell script:

![image](https://github.com/community-tech-alliance/dbt-cta/assets/47834372/5a5b1f0a-8427-4944-a9ef-46628b0fc388)

Setting aside the `error from server (BadRequest)`, the list of files the script is attempting to copy doesn't include anything dbt-related. So my next step was to attempt to look around the pod filesystems manually to see if I could find the dbt files. But (predictably) the `config/` folder just looks like this, and I can locate no other files:

![image](https://github.com/community-tech-alliance/dbt-cta/assets/47834372/bc8482fd-4b8f-4c58-ac1f-582221e87546)

This was the result for both the source and destination pods, which were both Running at the time:

![image](https://github.com/community-tech-alliance/dbt-cta/assets/47834372/a98dde56-aeb9-49bb-ab75-244fa686a92d)

I couldn't find instructions for running this shell script so maybe I'm doing something wrong, anything jump out at you?

This is the Airbyte connection I'm playing with (I'm doing some science for P2P dev, it's nothing relating to current partner sync development): https://k8s.cta-tech.dev/workspaces/4f1821e9-c1a2-4b22-9265-120d2054355f/connections/5df6404b-089d-4cc7-8cca-ba9ea737a190/status