### PR TITLE
fix (quickbooks): missed three Quickbooks model reference replacements

### DIFF
--- a/dbt-cta/quickbooks/models/0_ctes/bill_payments_CheckPayment_BankAccountRef_ab1.sql
+++ b/dbt-cta/quickbooks/models/0_ctes/bill_payments_CheckPayment_BankAccountRef_ab1.sql
@@ -4,7 +4,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema
--- depends_on: {{ ref('bill_payments_CheckPayment') }}
+-- depends_on: {{ ref('bill_payments_CheckPayment_base') }}
 select
     _airbyte_CheckPayment_hashid,
     {{ json_extract_scalar('BankAccountRef', ['name'], ['name']) }} as name,
@@ -12,7 +12,7 @@ select
     _airbyte_ab_id,
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('bill_payments_CheckPayment') }} as table_alias
+from {{ ref('bill_payments_CheckPayment_base') }} as table_alias
 -- BankAccountRef at bill_payments/CheckPayment/BankAccountRef
 where 1 = 1
 and BankAccountRef is not null

--- a/dbt-cta/quickbooks/models/0_ctes/bill_payments_CreditCardPayment_CCAccountRef_ab1.sql
+++ b/dbt-cta/quickbooks/models/0_ctes/bill_payments_CreditCardPayment_CCAccountRef_ab1.sql
@@ -4,7 +4,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema
--- depends_on: {{ ref('bill_payments_CreditCardPayment') }}
+-- depends_on: {{ ref('bill_payments_CreditCardPayment_base') }}
 select
     _airbyte_CreditCardPayment_hashid,
     {{ json_extract_scalar('CCAccountRef', ['name'], ['name']) }} as name,
@@ -12,7 +12,7 @@ select
     _airbyte_ab_id,
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('bill_payments_CreditCardPayment') }} as table_alias
+from {{ ref('bill_payments_CreditCardPayment_base') }} as table_alias
 -- CCAccountRef at bill_payments/CreditCardPayment/CCAccountRef
 where 1 = 1
 and CCAccountRef is not null

--- a/dbt-cta/quickbooks/models/0_ctes/tax_codes_SalesTaxRateList_TaxRateDetail_ab1.sql
+++ b/dbt-cta/quickbooks/models/0_ctes/tax_codes_SalesTaxRateList_TaxRateDetail_ab1.sql
@@ -4,7 +4,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema
--- depends_on: {{ ref('tax_codes_SalesTaxRateList') }}
+-- depends_on: {{ ref('tax_codes_SalesTaxRateList_base') }}
 {{ unnest_cte(ref('tax_codes_SalesTaxRateList'), 'SalesTaxRateList', 'TaxRateDetail') }}
 select
     _airbyte_SalesTaxRateList_hashid,
@@ -14,7 +14,7 @@ select
     _airbyte_ab_id,
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('tax_codes_SalesTaxRateList') }} as table_alias
+from {{ ref('tax_codes_SalesTaxRateList_base') }} as table_alias
 -- TaxRateDetail at tax_codes/SalesTaxRateList/TaxRateDetail
 {{ cross_join_unnest('SalesTaxRateList', 'TaxRateDetail') }}
 where 1 = 1


### PR DESCRIPTION
Just a few stragglers were causing dbt to fail when implementing for a new partner.

These dbt commands succeed locally (Quickbooks has a billion models so this is best done one at a time):

```
dbt run --target cta --select bill_payments_CreditCardPayment_CCAccountRef_base
dbt run --target cta --select bill_payments_CheckPayment_BankAccountRef_base
dbt run --target cta --select tax_codes_SalesTaxRateList_TaxRateDetail_base
```