### PR TITLE
feat: add new profile that uses 1 thread (for chonker syncs)

### DIFF
--- a/dbt-cta/profiles.yml
+++ b/dbt-cta/profiles.yml
@@ -19,7 +19,7 @@ default:
       location: US
       method: oauth
       priority: batch
-      threads: 4
+      threads: "{{ env_var('DBT_THREADS') }}"
       type: bigquery
       job_creation_timeout_seconds: 30
       job_execution_timeout_seconds: 600

--- a/dbt-cta/profiles.yml
+++ b/dbt-cta/profiles.yml
@@ -19,7 +19,19 @@ default:
       location: US
       method: oauth
       priority: batch
-      threads: "{{ env_var('DBT_THREADS') }}"
+      threads: 4
+      type: bigquery
+      job_creation_timeout_seconds: 30
+      job_execution_timeout_seconds: 600
+      job_retries: 5
+      job_retry_deadline_seconds: 1200
+    cta_1_thread:
+      project: "{{ env_var('CTA_PROJECT_ID') }}"
+      dataset: "{{ env_var('CTA_DATASET_ID') }}"
+      location: US
+      method: oauth
+      priority: batch
+      threads: 1
       type: bigquery
       job_creation_timeout_seconds: 30
       job_execution_timeout_seconds: 600


### PR DESCRIPTION
This PR ~sets threads in profiles.yml to use an environment variable rather than hardcoded to 4~  adds a profile to `profiles.yml` that uses 1 thread instead of 4. (It would be nice to pass in `threads` as an env var, but jinja templating returns variables as strings, when it needs to be an integer for the dbt to run.)

These changes should be reviewed and merged in tandem with [this PR in airflow-dags](https://github.com/community-tech-alliance/airflow-dags/pull/548), which ~exports that env_var in all DAGs that use dbt~ uses a variable to set the `target` when running dbt on the cta profile, which allows us to set that variable to use the 1-thread profile as desired (currently only for blocks).