### PR TITLE
feat: deliver elementary data to `{CTA_DATASET_ID}_elementary`

### DIFF
--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -12,7 +12,7 @@ models:
     relation: true
     columns: true
   elementary:
-    +schema: "elementary"
+    schema: "elementary"
     database:  "{{ env_var('CTA_PROJECT_ID') }}"
   default:
     0_ctes:

--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -12,7 +12,7 @@ models:
     relation: true
     columns: true
   elementary:
-    schema: "elementary"
+    +schema: "elementary"
     database:  "{{ env_var('CTA_PROJECT_ID') }}"
   default:
     0_ctes:

--- a/dbt-cta/profiles.yml
+++ b/dbt-cta/profiles.yml
@@ -49,11 +49,3 @@ default:
       job_execution_timeout_seconds: 600
       job_retries: 5
       job_retry_deadline_seconds: 1200
-elementary:
-  outputs:
-    default:
-      type: bigquery
-      method: oauth
-      project: "{{ env_var('CTA_PROJECT_ID') }}"
-      dataset: "elementary_{{ env_var('CTA_DATASET_ID') }}"
-      threads: 4

--- a/dbt-cta/profiles.yml
+++ b/dbt-cta/profiles.yml
@@ -55,5 +55,5 @@ elementary:
       type: bigquery
       method: oauth
       project: "{{ env_var('CTA_PROJECT_ID') }}"
-      dataset: "elementary_{{ env_var('CTA_DATASET_ID') }}"
+      dataset: "elementary"
       threads: 4

--- a/dbt-cta/profiles.yml
+++ b/dbt-cta/profiles.yml
@@ -55,5 +55,5 @@ elementary:
       type: bigquery
       method: oauth
       project: "{{ env_var('CTA_PROJECT_ID') }}"
-      dataset: elementary
+      dataset: "elementary_{{ env_var('CTA_DATASET_ID') }}"
       threads: 4

--- a/dbt-cta/profiles.yml
+++ b/dbt-cta/profiles.yml
@@ -49,3 +49,11 @@ default:
       job_execution_timeout_seconds: 600
       job_retries: 5
       job_retry_deadline_seconds: 1200
+elementary:
+  outputs:
+    default:
+      type: bigquery
+      method: oauth
+      project: "{{ env_var('CTA_PROJECT_ID') }}"
+      dataset: "elementary_{{ env_var('CTA_DATASET_ID') }}"
+      threads: 4


### PR DESCRIPTION
I thought this wasn't working because running locally didn't appear to write any tables to elementary at the intended new destination, but it DOES seem to work when run on composer, so I guess this strat really does work after all?

NOPE it doesn't

really just ignore this PR ok ty