### PR TITLE
hotfix: parse and cast `date` field to date datatype

### DIFF
--- a/dbt-cta/google_analytics_ga4/models/0_ctes/daily_active_users_ab1.sql
+++ b/dbt-cta/google_analytics_ga4/models/0_ctes/daily_active_users_ab1.sql
@@ -10,7 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
-    date,
+    PARSE_DATE("%Y%m%d", date) as date,
     active1DayUsers,
     property_id,
    {{ dbt_utils.surrogate_key([

--- a/dbt-cta/google_analytics_ga4/models/0_ctes/devices_ab1.sql
+++ b/dbt-cta/google_analytics_ga4/models/0_ctes/devices_ab1.sql
@@ -10,7 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
-    date,
+    PARSE_DATE("%Y%m%d", date) as date,
     newUsers,
     sessions,
     sessionsPerUser,

--- a/dbt-cta/google_analytics_ga4/models/0_ctes/four_weekly_active_users_ab1.sql
+++ b/dbt-cta/google_analytics_ga4/models/0_ctes/four_weekly_active_users_ab1.sql
@@ -10,7 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
-    date,
+    PARSE_DATE("%Y%m%d", date) as date,
     active28DayUsers,
     property_id,
    {{ dbt_utils.surrogate_key([

--- a/dbt-cta/google_analytics_ga4/models/0_ctes/locations_ab1.sql
+++ b/dbt-cta/google_analytics_ga4/models/0_ctes/locations_ab1.sql
@@ -10,7 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
-    date,
+    PARSE_DATE("%Y%m%d", date) as date,
     country,
     newUsers,
     sessions,

--- a/dbt-cta/google_analytics_ga4/models/0_ctes/pages_ab1.sql
+++ b/dbt-cta/google_analytics_ga4/models/0_ctes/pages_ab1.sql
@@ -10,7 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
-    date,
+    PARSE_DATE("%Y%m%d", date) as date,
     hostName,
     screenPageViews,
     pagePathPlusQueryString,

--- a/dbt-cta/google_analytics_ga4/models/0_ctes/traffic_sources_ab1.sql
+++ b/dbt-cta/google_analytics_ga4/models/0_ctes/traffic_sources_ab1.sql
@@ -10,7 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
-    date,
+    PARSE_DATE("%Y%m%d", date) as date,
     newUsers,
     sessions,
     sessionSource,

--- a/dbt-cta/google_analytics_ga4/models/0_ctes/website_overview_ab1.sql
+++ b/dbt-cta/google_analytics_ga4/models/0_ctes/website_overview_ab1.sql
@@ -10,7 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
-    date,
+    PARSE_DATE("%Y%m%d", date) as date,
     newUsers,
     sessions,
     sessionsPerUser,

--- a/dbt-cta/google_analytics_ga4/models/0_ctes/weekly_active_users_ab1.sql
+++ b/dbt-cta/google_analytics_ga4/models/0_ctes/weekly_active_users_ab1.sql
@@ -10,7 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
-    date,
+    PARSE_DATE("%Y%m%d", date) as date,
     active7DayUsers,
     property_id,
    {{ dbt_utils.surrogate_key([


### PR DESCRIPTION
this succeeds locally - all it does is change the `date` field in the Google Analytics GA4 models to be a DATE type in BQ instead of a string (seems reasonable)