### PR TITLE
feat: extend date replacement strat to past 6 days

### DIFF
--- a/dbt-cta/action_builder/models/1_cta_full_refresh/action_assignment_group_users_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/action_assignment_group_users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/action_assignment_groups_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/action_assignment_groups_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/action_assignments_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/action_assignments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/action_entities_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/action_entities_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/action_fields_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/action_fields_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/actions_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/actions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/activity_events_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/activity_events_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/addresses_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/addresses_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/addresses_electoral_districts_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/addresses_electoral_districts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/api_keys_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/api_keys_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/ar_internal_metadata_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/ar_internal_metadata_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/assessments_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/assessments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/attachments_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/attachments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_configuration_tag_categories_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_configuration_tag_categories_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_context_notes_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_context_notes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_entity_type_configurations_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_entity_type_configurations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_entity_types_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_entity_types_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_participations_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_participations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_topline_setting_items_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaign_topline_setting_items_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_entities_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_entities_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_entity_connection_types_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_entity_connection_types_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_tag_categories_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_tag_categories_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_tag_groups_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_tag_groups_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_tags_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/campaigns_tags_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/contact_attempts_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/contact_attempts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/contact_sources_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/contact_sources_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/contact_statuses_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/contact_statuses_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/electoral_districts_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/electoral_districts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/emails_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/emails_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/entities_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/entities_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/entity_connection_types_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/entity_connection_types_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/entity_connections_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/entity_connections_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/entity_sync_cursors_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/entity_sync_cursors_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/entity_sync_states_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/entity_sync_states_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/entity_sync_stored_operations_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/entity_sync_stored_operations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/entity_types_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/entity_types_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/external_services_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/external_services_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/follow_ups_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/follow_ups_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/global_notes_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/global_notes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/integrations_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/integrations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/organization_integration_links_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/organization_integration_links_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/organization_integrations_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/organization_integrations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/organizations_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/organizations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/phone_numbers_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/phone_numbers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/queries_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/queries_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/query_results_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/query_results_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/relationships_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/relationships_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/schema_migrations_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/schema_migrations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/shift_times_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/shift_times_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/shifts_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/shifts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/signatures_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/signatures_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/social_profiles_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/social_profiles_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/subscription_statuses_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/subscription_statuses_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/tag_categories_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/tag_categories_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/tag_groups_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/tag_groups_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/taggable_logbook_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/taggable_logbook_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/tags_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/tags_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/tasks_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/tasks_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/turf_assignments_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/turf_assignments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/turf_tags_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/turf_tags_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/uploads_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/uploads_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/users_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_builder/models/1_cta_full_refresh/versions_base.sql
+++ b/dbt-cta/action_builder/models/1_cta_full_refresh/versions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/action_keywords_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/action_keywords_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/action_questions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/action_questions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/actions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/answers_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/answers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/call_campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/call_campaigns_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/call_targets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/call_targets_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/calls_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/calls_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/campaigns_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/catalist_syncs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/catalist_syncs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/child_permissions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/child_permissions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/collections_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/collections_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/collections_groups_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/collections_groups_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/comments_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/comments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_field_syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_field_syndications_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_field_timezones_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_field_timezones_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_counties_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_counties_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_ocdids_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_ocdids_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/counties_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/counties_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/deliveries_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/deliveries_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/delivery_targets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/delivery_targets_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donation_payments_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donation_payments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donation_recipients_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donation_recipients_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donations_recurring_donations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donations_recurring_donations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_10_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_10_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_11_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_11_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_12_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_12_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_13_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_13_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_14_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_14_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_15_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_15_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_16_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_16_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_1_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_1_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_2_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_2_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_3_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_3_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_4_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_4_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_5_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_5_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_6_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_6_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_7_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_7_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_8_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_8_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_9_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_9_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_campaign_members_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_campaign_members_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_campaigns_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_fields_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_fields_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_stats_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_stats_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_templates_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_templates_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_tests_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_tests_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/emails_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/emails_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_invites_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_invites_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_uploads_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_uploads_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/event_campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/event_campaigns_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/events_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/events_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/field_names_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/field_names_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/field_names_groups_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/field_names_groups_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/field_values_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/field_values_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/filter_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/filter_actions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/filters_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/filters_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/forms_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/forms_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/fundraisings_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/fundraisings_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_actions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_codes_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_codes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/group_invites_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/group_invites_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/groups_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/groups_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/groups_syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/groups_syndications_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/groups_users_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/groups_users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ladders_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ladders_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/letter_templates_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/letter_templates_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/letters_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/letters_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/lists_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/lists_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/locations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/locations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/message_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/message_actions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_fields_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_fields_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_stats_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_stats_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/mobile_messages_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/mobile_messages_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/networks_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/networks_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/networks_users_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/networks_users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/notification_settings_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/notification_settings_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ocdids_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ocdids_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/page_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/page_actions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/page_wrappers_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/page_wrappers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/petitions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/petitions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/phone_change_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/phone_change_logs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/phone_dedupe_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/phone_dedupe_logs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/queries_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/queries_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/questions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/questions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/recurring_donations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/recurring_donations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/reports_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/reports_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/rsvps_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/rsvps_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/share_options_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/share_options_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/signatures_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/signatures_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_message_activities_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_message_activities_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_messages_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_messages_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_status_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_status_logs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_statuses_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_statuses_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_unsubscriptions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_unsubscriptions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/source_codes_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/source_codes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/steps_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/steps_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/subscription_statuses_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/subscription_statuses_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_1_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_1_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/syndications_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/tag_syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/tag_syndications_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/tags_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/tags_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/targets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/targets_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ticket_receipts_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ticket_receipts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ticketed_events_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ticketed_events_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/tickets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/tickets_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/triggers_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/triggers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/unsubscriptions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/unsubscriptions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_files_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_files_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_ladder_statuses_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_ladder_statuses_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_1_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_1_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_source_codes_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_source_codes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_tags_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_tags_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_tickets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_tickets_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/users_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/webhook_messages_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/webhook_messages_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/action_network/models/1_cta_full_refresh/webhooks_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/webhooks_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/ctaResults_answerIdsByPromptId_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/ctaResults_answerIdsByPromptId_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/ctaResults_answers_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/ctaResults_answers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/ctaResults_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/ctaResults_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/ctas_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/ctas_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/ctas_prompts_answers_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/ctas_prompts_answers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/ctas_prompts_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/ctas_prompts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/ctas_questions_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/ctas_questions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/ctas_shareables_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/ctas_shareables_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/outreachEntries_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/outreachEntries_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/profileOrganizationTags_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/profileOrganizationTags_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/profiles_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/profiles_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/empower/models/1_cta_full_refresh/regions_base.sql
+++ b/dbt-cta/empower/models/1_cta_full_refresh/regions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/facebook_pages/models/1_cta_full_refresh/page_base.sql
+++ b/dbt-cta/facebook_pages/models/1_cta_full_refresh/page_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/facebook_pages/models/1_cta_full_refresh/page_insights_base.sql
+++ b/dbt-cta/facebook_pages/models/1_cta_full_refresh/page_insights_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/facebook_pages/models/1_cta_full_refresh/post_base.sql
+++ b/dbt-cta/facebook_pages/models/1_cta_full_refresh/post_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/facebook_pages/models/1_cta_full_refresh/post_insights_base.sql
+++ b/dbt-cta/facebook_pages/models/1_cta_full_refresh/post_insights_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/activities_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/activities_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/activity_scripts_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/activity_scripts_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/campaigns_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/campaigns_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/contacts_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/contacts_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/customizations_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/customizations_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/forms_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/forms_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/messages_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/messages_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/person_api_lookups_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/person_api_lookups_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/registrations_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/registrations_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/reports_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/reports_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/taggings_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/taggings_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/teams_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/teams_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/user_activities_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/user_activities_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/user_activity_performances_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/user_activity_performances_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/user_campaigns_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/user_campaigns_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/users_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/users_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/v2_voice_calls_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/v2_voice_calls_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/impactive/models/1_cta_full_refresh/voice_calls_export_base.sql
+++ b/dbt-cta/impactive/models/1_cta_full_refresh/voice_calls_export_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/activities_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/activities_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/applicants_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/applicants_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/applicants_to_jobs_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/applicants_to_jobs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/categories_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/categories_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/categories_to_applicants_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/categories_to_applicants_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/contacts_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/contacts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/hires_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/hires_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/jobs_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/jobs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/questionnaire_answers_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/questionnaire_answers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/tasks_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/tasks_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/jazzhr/models/1_cta_full_refresh/users_base.sql
+++ b/dbt-cta/jazzhr/models/1_cta_full_refresh/users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/openfield/models/1_cta_full_refresh/knock_conversation_code_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/knock_conversation_code_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_cta_loaded_at",

--- a/dbt-cta/openfield/models/1_cta_full_refresh/knock_people_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/knock_people_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_cta_loaded_at",

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_attempts_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_attempts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_cta_loaded_at",

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_celloptins_conversations_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_celloptins_conversations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_cta_loaded_at",

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_email_conversations_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_email_conversations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_cta_loaded_at",

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_list_conversations_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_list_conversations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_cta_loaded_at",

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_longtext_conversations_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_longtext_conversations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_cta_loaded_at",

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_name_conversations_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_name_conversations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_cta_loaded_at",

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_shorttext_conversations_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_shorttext_conversations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_cta_loaded_at",

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_truefalse_conversations_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_truefalse_conversations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_cta_loaded_at",

--- a/dbt-cta/point_to_point/google_sheets_van_apply_activist_codes/models/1_cta_full_refresh/apply_activist_codes_base.sql
+++ b/dbt-cta/point_to_point/google_sheets_van_apply_activist_codes/models/1_cta_full_refresh/apply_activist_codes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/point_to_point/google_sheets_van_upsert_contacts/models/1_cta_full_refresh/upsert_contacts_base.sql
+++ b/dbt-cta/point_to_point/google_sheets_van_upsert_contacts/models/1_cta_full_refresh/upsert_contacts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/accounts_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/accounts_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/accounts_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/accounts_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/accounts_ParentRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/accounts_ParentRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/accounts_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/accounts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_APAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_APAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_CheckPayment_BankAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_CheckPayment_BankAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_CheckPayment_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_CheckPayment_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_CreditCardPayment_CCAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_CreditCardPayment_CCAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_CreditCardPayment_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_CreditCardPayment_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_DepartmentRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_DepartmentRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_Line_LinkedTxn_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_Line_LinkedTxn_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_VendorRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_VendorRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bill_payments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_APAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_APAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_DepartmentRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_DepartmentRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_AccountBasedExpenseLineDetail_AccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_AccountBasedExpenseLineDetail_AccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_AccountBasedExpenseLineDetail_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_AccountBasedExpenseLineDetail_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_AccountBasedExpenseLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_AccountBasedExpenseLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_AccountBasedExpenseLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_AccountBasedExpenseLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_ItemBasedExpenseLineDetail_ItemRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_ItemBasedExpenseLineDetail_ItemRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_ItemBasedExpenseLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_ItemBasedExpenseLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_ItemBasedExpenseLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_ItemBasedExpenseLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_LinkedTxn_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_LinkedTxn_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_SalesTermRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_SalesTermRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_VendorRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_VendorRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/bills_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_BudgetDetail_AccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_BudgetDetail_AccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_BudgetDetail_ClassRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_BudgetDetail_ClassRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_BudgetDetail_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_BudgetDetail_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_BudgetDetail_DepartmentRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_BudgetDetail_DepartmentRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_BudgetDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_BudgetDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/budgets_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/classes_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/classes_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/classes_ParentRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/classes_ParentRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/classes_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/classes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_BillAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_BillAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_BillEmail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_BillEmail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_ClassRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_ClassRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_CustomField_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_CustomField_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_CustomerMemo_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_CustomerMemo_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_Line_SalesItemLineDetail_ItemRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_Line_SalesItemLineDetail_ItemRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_Line_SalesItemLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_Line_SalesItemLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_Line_SalesItemLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_Line_SalesItemLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_SalesTermRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_SalesTermRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_ShipAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_ShipAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_TxnTaxDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_TxnTaxDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/credit_memos_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_BillAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_BillAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_DefaultTaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_DefaultTaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_Fax_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_Fax_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_Mobile_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_Mobile_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_ParentRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_ParentRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_PaymentMethodRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_PaymentMethodRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_PrimaryEmailAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_PrimaryEmailAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_PrimaryPhone_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_PrimaryPhone_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_SalesTermRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_SalesTermRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_ShipAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_ShipAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_WebAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_WebAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/customers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/departments_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/departments_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/departments_ParentRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/departments_ParentRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/departments_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/departments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_CashBack_AccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_CashBack_AccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_CashBack_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_CashBack_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_DepartmentRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_DepartmentRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_DepositToAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_DepositToAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_Line_DepositLineDetail_AccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_Line_DepositLineDetail_AccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_Line_DepositLineDetail_PaymentMethodRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_Line_DepositLineDetail_PaymentMethodRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_Line_DepositLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_Line_DepositLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_Line_LinkedTxn_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_Line_LinkedTxn_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/deposits_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/employees_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/employees_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/employees_PrimaryPhone_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/employees_PrimaryPhone_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/employees_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/employees_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_BillAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_BillAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_BillEmail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_BillEmail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_CustomField_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_CustomField_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_CustomerMemo_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_CustomerMemo_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_DeliveryInfo_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_DeliveryInfo_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_Line_SalesItemLineDetail_ItemRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_Line_SalesItemLineDetail_ItemRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_Line_SalesItemLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_Line_SalesItemLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_Line_SalesItemLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_Line_SalesItemLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_LinkedTxn_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_LinkedTxn_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_ShipAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_ShipAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_TxnTaxDetail_TaxLine_TaxLineDetail_TaxRateRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_TxnTaxDetail_TaxLine_TaxLineDetail_TaxRateRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_TxnTaxDetail_TaxLine_TaxLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_TxnTaxDetail_TaxLine_TaxLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_TxnTaxDetail_TaxLine_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_TxnTaxDetail_TaxLine_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_TxnTaxDetail_TxnTaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_TxnTaxDetail_TxnTaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_TxnTaxDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_TxnTaxDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/estimates_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_BillAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_BillAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_BillEmail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_BillEmail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_CustomField_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_CustomField_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_CustomerMemo_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_CustomerMemo_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_DeliveryInfo_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_DeliveryInfo_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_DiscountLineDetail_DiscountAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_DiscountLineDetail_DiscountAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_DiscountLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_DiscountLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_LinkedTxn_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_LinkedTxn_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_SalesItemLineDetail_ClassRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_SalesItemLineDetail_ClassRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_SalesItemLineDetail_ItemRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_SalesItemLineDetail_ItemRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_SalesItemLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_SalesItemLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_SalesItemLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_SalesItemLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_LinkedTxn_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_LinkedTxn_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_SalesTermRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_SalesTermRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_ShipAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_ShipAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_TxnTaxDetail_TaxLine_TaxLineDetail_TaxRateRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_TxnTaxDetail_TaxLine_TaxLineDetail_TaxRateRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_TxnTaxDetail_TaxLine_TaxLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_TxnTaxDetail_TaxLine_TaxLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_TxnTaxDetail_TaxLine_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_TxnTaxDetail_TaxLine_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_TxnTaxDetail_TxnTaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_TxnTaxDetail_TxnTaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_TxnTaxDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_TxnTaxDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/invoices_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/items_AssetAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/items_AssetAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/items_ExpenseAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/items_ExpenseAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/items_IncomeAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/items_IncomeAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/items_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/items_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/items_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/items_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_Line_JournalEntryLineDetail_AccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_Line_JournalEntryLineDetail_AccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_Line_JournalEntryLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_Line_JournalEntryLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TaxRateRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TaxRateRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TxnTaxDetail_TaxLine_TaxLineDetail_TaxRateRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TxnTaxDetail_TaxLine_TaxLineDetail_TaxRateRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TxnTaxDetail_TaxLine_TaxLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TxnTaxDetail_TaxLine_TaxLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TxnTaxDetail_TaxLine_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TxnTaxDetail_TaxLine_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TxnTaxDetail_TxnTaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TxnTaxDetail_TxnTaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TxnTaxDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_TxnTaxDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/journal_entries_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payment_methods_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payment_methods_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payment_methods_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payment_methods_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_ARAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_ARAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_DepositToAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_DepositToAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_Line_LineEx_any_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_Line_LineEx_any_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_Line_LineEx_any_value_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_Line_LineEx_any_value_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_Line_LineEx_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_Line_LineEx_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_Line_LinkedTxn_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_Line_LinkedTxn_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_LinkedTxn_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_LinkedTxn_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_PaymentMethodRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_PaymentMethodRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/payments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_APAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_APAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_ClassRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_ClassRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_CustomField_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_CustomField_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_DepartmentRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_DepartmentRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_ItemBasedExpenseLineDetail_ClassRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_ItemBasedExpenseLineDetail_ClassRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_ItemBasedExpenseLineDetail_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_ItemBasedExpenseLineDetail_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_ItemBasedExpenseLineDetail_ItemRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_ItemBasedExpenseLineDetail_ItemRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_ItemBasedExpenseLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_ItemBasedExpenseLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_ItemBasedExpenseLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_ItemBasedExpenseLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_LinkedTxn_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_LinkedTxn_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_SalesTermRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_SalesTermRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_ShipAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_ShipAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_ShipTo_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_ShipTo_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_VendorAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_VendorAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_VendorRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_VendorRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchase_orders_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_AccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_AccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_EntityRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_EntityRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_AccountBasedExpenseLineDetail_AccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_AccountBasedExpenseLineDetail_AccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_AccountBasedExpenseLineDetail_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_AccountBasedExpenseLineDetail_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_AccountBasedExpenseLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_AccountBasedExpenseLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_AccountBasedExpenseLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_AccountBasedExpenseLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_ItemBasedExpenseLineDetail_ItemRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_ItemBasedExpenseLineDetail_ItemRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_ItemBasedExpenseLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_ItemBasedExpenseLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_ItemBasedExpenseLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_ItemBasedExpenseLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_PurchaseEx_any_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_PurchaseEx_any_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_PurchaseEx_any_value_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_PurchaseEx_any_value_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_PurchaseEx_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_PurchaseEx_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_RemitToAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_RemitToAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/purchases_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_BillAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_BillAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_BillEmail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_BillEmail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_CustomField_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_CustomField_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_CustomerMemo_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_CustomerMemo_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_DepositToAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_DepositToAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_Line_SalesItemLineDetail_ItemRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_Line_SalesItemLineDetail_ItemRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_Line_SalesItemLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_Line_SalesItemLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_Line_SalesItemLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_Line_SalesItemLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_PaymentMethodRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_PaymentMethodRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_TxnTaxDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_TxnTaxDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/refund_receipts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_BillAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_BillAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_BillEmail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_BillEmail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_CustomField_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_CustomField_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_CustomerMemo_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_CustomerMemo_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_DepositToAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_DepositToAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_DiscountLineDetail_DiscountAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_DiscountLineDetail_DiscountAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_DiscountLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_DiscountLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_SalesItemLineDetail_ItemRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_SalesItemLineDetail_ItemRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_SalesItemLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_SalesItemLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_SalesItemLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_SalesItemLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_LinkedTxn_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_LinkedTxn_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_PaymentMethodRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_PaymentMethodRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_ShipAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_ShipAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_TxnTaxDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_TxnTaxDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/sales_receipts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_agencies_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_agencies_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_agencies_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_agencies_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_codes_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_codes_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_codes_SalesTaxRateList_TaxRateDetail_TaxRateRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_codes_SalesTaxRateList_TaxRateDetail_TaxRateRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_codes_SalesTaxRateList_TaxRateDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_codes_SalesTaxRateList_TaxRateDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_codes_SalesTaxRateList_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_codes_SalesTaxRateList_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_codes_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_codes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_rates_AgencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_rates_AgencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_rates_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_rates_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_rates_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/tax_rates_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/terms_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/terms_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/terms_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/terms_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/time_activities_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/time_activities_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/time_activities_EmployeeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/time_activities_EmployeeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/time_activities_ItemRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/time_activities_ItemRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/time_activities_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/time_activities_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/time_activities_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/time_activities_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/transfers_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/transfers_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/transfers_FromAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/transfers_FromAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/transfers_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/transfers_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/transfers_ToAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/transfers_ToAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/transfers_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/transfers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_APAccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_APAccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_DepartmentRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_DepartmentRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_AccountBasedExpenseLineDetail_AccountRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_AccountBasedExpenseLineDetail_AccountRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_AccountBasedExpenseLineDetail_ClassRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_AccountBasedExpenseLineDetail_ClassRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_AccountBasedExpenseLineDetail_CustomerRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_AccountBasedExpenseLineDetail_CustomerRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_AccountBasedExpenseLineDetail_TaxCodeRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_AccountBasedExpenseLineDetail_TaxCodeRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_AccountBasedExpenseLineDetail_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_AccountBasedExpenseLineDetail_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_Line_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_VendorRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_VendorRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendor_credits_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_BillAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_BillAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_CurrencyRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_CurrencyRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_Fax_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_Fax_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_MetaData_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_MetaData_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_Mobile_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_Mobile_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_PrimaryEmailAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_PrimaryEmailAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_PrimaryPhone_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_PrimaryPhone_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_TermRef_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_TermRef_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_WebAddr_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_WebAddr_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_base.sql
+++ b/dbt-cta/quickbooks/models/1_cta_full_refresh/vendors_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/spoke/models/1_cta_full_refresh/assignable_campaign_contacts_base.sql
+++ b/dbt-cta/spoke/models/1_cta_full_refresh/assignable_campaign_contacts_base.sql
@@ -1,7 +1,12 @@
 
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
     
 {{config(

--- a/dbt-cta/spoke/models/1_cta_full_refresh/assignable_campaign_contacts_with_escalation_tags_base.sql
+++ b/dbt-cta/spoke/models/1_cta_full_refresh/assignable_campaign_contacts_with_escalation_tags_base.sql
@@ -1,7 +1,12 @@
 
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
     
 {{config(

--- a/dbt-cta/spoke/models/1_cta_full_refresh/assignable_campaigns_base.sql
+++ b/dbt-cta/spoke/models/1_cta_full_refresh/assignable_campaigns_base.sql
@@ -1,7 +1,12 @@
 
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
     
 {{config(

--- a/dbt-cta/spoke/models/1_cta_full_refresh/question_response_base.sql
+++ b/dbt-cta/spoke/models/1_cta_full_refresh/question_response_base.sql
@@ -1,7 +1,12 @@
 
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
     
 {{config(

--- a/dbt-cta/spoke/models/1_cta_full_refresh/tag_base.sql
+++ b/dbt-cta/spoke/models/1_cta_full_refresh/tag_base.sql
@@ -1,7 +1,12 @@
 
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
     
 {{config(

--- a/dbt-cta/spoke/models/1_cta_full_refresh/user_base.sql
+++ b/dbt-cta/spoke/models/1_cta_full_refresh/user_base.sql
@@ -1,7 +1,12 @@
 
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
     
 {{config(

--- a/dbt-cta/spoke/models/1_cta_full_refresh/zip_code_base.sql
+++ b/dbt-cta/spoke/models/1_cta_full_refresh/zip_code_base.sql
@@ -1,7 +1,12 @@
 
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
     
 {{config(

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/client_metadata_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/client_metadata_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/customer_groups_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/customer_groups_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/customer_profiles_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/customer_profiles_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/customer_tags_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/customer_tags_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/customer_users_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/customer_users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/facebook_post_analytics_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/facebook_post_analytics_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/facebook_profile_analytics_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/facebook_profile_analytics_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/instagram_post_analytics_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/instagram_post_analytics_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/instagram_profile_analytics_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/instagram_profile_analytics_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/tiktok_post_analytics_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/tiktok_post_analytics_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/sprout_social/models/1_cta_full_refresh/tiktok_profile_analytics_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_full_refresh/tiktok_profile_analytics_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/zoho_creator_meta/models/1_cta_full_refresh/applications_base.sql
+++ b/dbt-cta/zoho_creator_meta/models/1_cta_full_refresh/applications_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/zoho_creator_meta/models/1_cta_full_refresh/fields_base.sql
+++ b/dbt-cta/zoho_creator_meta/models/1_cta_full_refresh/fields_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/zoho_creator_meta/models/1_cta_full_refresh/forms_base.sql
+++ b/dbt-cta/zoho_creator_meta/models/1_cta_full_refresh/forms_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/zoho_creator_meta/models/1_cta_full_refresh/pages_base.sql
+++ b/dbt-cta/zoho_creator_meta/models/1_cta_full_refresh/pages_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/zoho_creator_meta/models/1_cta_full_refresh/reports_base.sql
+++ b/dbt-cta/zoho_creator_meta/models/1_cta_full_refresh/reports_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",


### PR DESCRIPTION
This is an extremely courageous PR that will probably crash Github if you look at the files changed. All I did was a find-and-replace on the following:

Replace:

```
{% set partitions_to_replace = [
    "timestamp_trunc(current_timestamp, day)",
    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
```

With:

```
{% set partitions_to_replace = [
    "timestamp_trunc(current_timestamp, day)",
    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
```

The aim of this is to make our full-refresh models a bit more resilient to temporary outages in the sync (which cause dbt tests to fail because duplicate data appear in separate date partitions).

@jitoquinto , @kanelouise , @Frydafly , any flags you see with this approach? Of course we can kick the tires in dev a bunch before deploying.