### PR TITLE
hotfix: deduping CTEs should `EXCEPT (rownum)`

### DIFF
--- a/utils/generate_dbt/templates/0_ctes_ab2.sql
+++ b/utils/generate_dbt/templates/0_ctes_ab2.sql
@@ -1,7 +1,7 @@
 -- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
-SELECT * FROM 
+SELECT * EXCEPT (rownum) FROM 
 (
 SELECT 
     *,


### PR DESCRIPTION
Just a small change to one of the SQL templates used to generate dbt for BQ V2 syncs in order to exclude the field `rownum` from appearing in the final data.