### PR TITLE
feat: new script for generating _ab4 deduping CTEs

### DIFF
--- a/utils/generate_dbt/generate_deduping_ctes.py
+++ b/utils/generate_dbt/generate_deduping_ctes.py
@@ -21,7 +21,7 @@ def main():
     folder_path = f"../../dbt-cta/{sync_name}/models/0_ctes"
 
     # Read the template from the separate .sql file
-    with open("templates/0_ctes_ab2.sql", "r") as template_file:
+    with open("templates/0_ctes_ab4.sql", "r") as template_file:
         template_content = template_file.read()
 
     # Create a Jinja2 template from the template content

--- a/utils/generate_dbt/generate_deduping_ctes.py
+++ b/utils/generate_dbt/generate_deduping_ctes.py
@@ -42,6 +42,21 @@ def main():
                 # Write the SQL content to the new file
                 with open(os.path.join(folder_path, new_filename), "w") as new_file:
                     new_file.write(sql_content)
+
+    # Update references in _base models (find and replace '_ab3' with '_ab4' in folders starting with '1_')
+    models_path = f"../../dbt-cta/{sync_name}/models"
+    for root, dirs, files in os.walk(models_path):
+        for dir_name in dirs:
+            if dir_name.startswith("1_"):
+                dir_path = os.path.join(root, dir_name)
+                for file_name in os.listdir(dir_path):
+                    if file_name.endswith(".sql"):
+                        file_path = os.path.join(dir_path, file_name)
+                        with open(file_path, "r") as file:
+                            content = file.read()
+                        content = content.replace("_ab3", "_ab4")
+                        with open(file_path, "w") as file:
+                            file.write(content)
             
 if __name__ == "__main__":
     main()

--- a/utils/generate_dbt/generate_deduping_ctes.py
+++ b/utils/generate_dbt/generate_deduping_ctes.py
@@ -1,0 +1,47 @@
+import os
+from jinja2 import Template
+
+"""
+This script generates deduping CTEs for all tables in the 0_ctes folder.
+This is specifically for use with dbt projects that have 3 CTEs in 0_ctes.
+(For example, ones originally created using the BQ V1 destination in Airbyte.)
+
+Example usage:
+
+cd utils/generate_dbt
+pipenv run python generate_deduping_ctes.py
+
+"""
+
+def main():
+    # Ask the user for the sync name
+    sync_name = input("Enter the sync name: ")
+
+    # Construct the folder path based on the sync name
+    folder_path = f"../../dbt-cta/{sync_name}/models/0_ctes"
+
+    # Read the template from the separate .sql file
+    with open("templates/0_ctes_ab2.sql", "r") as template_file:
+        template_content = template_file.read()
+
+    # Create a Jinja2 template from the template content
+    template = Template(template_content)
+
+    # Iterate through all files in the folder
+    for filename in os.listdir(folder_path):
+        if filename.endswith("_ab3.sql"):
+            # Extract the table name from the filename
+            table = filename.replace("_ab3.sql", "")
+
+            # Check if _ab4.sql already exists for this table
+            new_filename = f"{table}_ab4.sql"
+            if not os.path.exists(os.path.join(folder_path, new_filename)):
+                # Render the SQL template with the table name
+                sql_content = template.render(table=table)
+
+                # Write the SQL content to the new file
+                with open(os.path.join(folder_path, new_filename), "w") as new_file:
+                    new_file.write(sql_content)
+            
+if __name__ == "__main__":
+    main()

--- a/utils/generate_dbt/templates/0_ctes_ab4.sql
+++ b/utils/generate_dbt/templates/0_ctes_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_{{ table }}_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {% raw %}{{ ref('{% endraw %}{{ table }}{% raw %}_ab3') }}{% endraw %}
+)
+where rownum=1


### PR DESCRIPTION
This PR adds a quick and dirty script that iterates through the tables in a project (determined via user input) and generates `0_ctes/TABLE_ab4.sql` files that dedupe rows using the `_hashid` field in each table.

Because this is quick and dirty, the script hardcodes the template being used to generate the SQL, and assumes that the desired filename has the suffix `_ab4`. This should be fine for most or all of our syncs that still do not have these CTEs included, and the main purpose of this script is to facilitate adding those models to existing projects. Future syncs will use `generate_dbt.py` to generate dbt models, and that script already creates deduping CTEs, so this script will no longer be useful once all existing projects have had these models added.