### PR TITLE
feat (action network): add _ab4 CTEs to dedupe on _hashid fields

### DIFF
--- a/dbt-cta/action_network/models/0_ctes/action_keywords_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/action_keywords_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_action_keywords_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('action_keywords_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/action_questions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/action_questions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_action_questions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('action_questions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/actions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/actions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_actions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('actions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/answers_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/answers_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_answers_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('answers_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/call_campaigns_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/call_campaigns_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_call_campaigns_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('call_campaigns_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/call_targets_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/call_targets_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_call_targets_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('call_targets_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/calls_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/calls_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_calls_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('calls_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/campaigns_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/campaigns_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_campaigns_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('campaigns_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/catalist_syncs_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/catalist_syncs_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_catalist_syncs_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('catalist_syncs_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/child_permissions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/child_permissions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_child_permissions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('child_permissions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/collections_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/collections_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_collections_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('collections_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/collections_groups_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/collections_groups_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_collections_groups_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('collections_groups_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/comments_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/comments_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_comments_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('comments_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/core_field_syndications_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/core_field_syndications_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_core_field_syndications_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('core_field_syndications_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/core_field_timezones_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/core_field_timezones_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_core_field_timezones_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('core_field_timezones_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/core_fields_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/core_fields_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_core_fields_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('core_fields_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/core_fields_counties_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/core_fields_counties_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_core_fields_counties_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('core_fields_counties_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/core_fields_ocdids_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/core_fields_ocdids_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_core_fields_ocdids_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('core_fields_ocdids_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/counties_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/counties_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_counties_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('counties_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/deliveries_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/deliveries_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_deliveries_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('deliveries_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/delivery_targets_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/delivery_targets_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_delivery_targets_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('delivery_targets_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/donation_payments_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/donation_payments_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_donation_payments_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('donation_payments_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/donation_recipients_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/donation_recipients_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_donation_recipients_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('donation_recipients_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/donations_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/donations_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_donations_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('donations_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/donations_recurring_donations_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/donations_recurring_donations_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_donations_recurring_donations_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('donations_recurring_donations_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_10_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_10_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_10_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_10_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_11_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_11_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_11_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_11_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_12_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_12_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_12_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_12_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_13_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_13_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_13_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_13_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_14_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_14_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_14_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_14_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_15_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_15_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_15_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_15_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_16_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_16_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_16_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_16_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_1_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_1_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_1_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_1_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_2_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_2_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_2_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_2_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_3_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_3_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_3_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_3_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_4_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_4_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_4_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_4_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_5_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_5_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_5_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_5_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_6_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_6_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_6_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_6_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_7_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_7_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_7_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_7_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_8_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_8_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_8_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_8_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_9_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_9_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_9_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_9_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_activities_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_activities_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_activities_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_activities_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_campaign_members_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_campaign_members_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_campaign_members_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_campaign_members_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_campaigns_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_campaigns_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_campaigns_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_campaigns_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_fields_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_fields_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_fields_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_fields_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_stats_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_stats_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_stats_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_stats_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_templates_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_templates_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_templates_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_templates_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/email_tests_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/email_tests_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_email_tests_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('email_tests_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/emails_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/emails_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_emails_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('emails_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/event_campaign_invites_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/event_campaign_invites_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_event_campaign_invites_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('event_campaign_invites_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/event_campaign_uploads_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/event_campaign_uploads_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_event_campaign_uploads_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('event_campaign_uploads_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/event_campaigns_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/event_campaigns_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_event_campaigns_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('event_campaigns_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/events_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/events_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_events_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('events_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/field_names_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/field_names_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_field_names_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('field_names_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/field_names_groups_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/field_names_groups_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_field_names_groups_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('field_names_groups_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/field_values_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/field_values_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_field_values_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('field_values_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/filter_actions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/filter_actions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_filter_actions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('filter_actions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/filters_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/filters_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_filters_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('filters_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/forms_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/forms_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_forms_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('forms_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/fundraisings_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/fundraisings_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_fundraisings_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('fundraisings_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/group_growth_by_source_actions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/group_growth_by_source_actions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_group_growth_by_source_actions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('group_growth_by_source_actions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/group_growth_by_source_codes_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/group_growth_by_source_codes_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_group_growth_by_source_codes_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('group_growth_by_source_codes_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/group_invites_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/group_invites_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_group_invites_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('group_invites_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/groups_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/groups_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_groups_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('groups_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/groups_syndications_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/groups_syndications_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_groups_syndications_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('groups_syndications_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/groups_users_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/groups_users_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_groups_users_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('groups_users_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/ladders_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/ladders_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_ladders_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('ladders_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/letter_templates_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/letter_templates_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_letter_templates_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('letter_templates_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/letters_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/letters_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_letters_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('letters_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/lists_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/lists_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_lists_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('lists_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/locations_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/locations_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_locations_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('locations_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/message_actions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/message_actions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_message_actions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('message_actions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/mobile_message_fields_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/mobile_message_fields_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_mobile_message_fields_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('mobile_message_fields_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/mobile_message_stats_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/mobile_message_stats_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_mobile_message_stats_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('mobile_message_stats_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/mobile_messages_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/mobile_messages_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_mobile_messages_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('mobile_messages_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/networks_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/networks_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_networks_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('networks_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/networks_users_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/networks_users_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_networks_users_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('networks_users_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/notification_settings_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/notification_settings_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_notification_settings_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('notification_settings_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/ocdids_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/ocdids_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_ocdids_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('ocdids_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/page_actions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/page_actions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_page_actions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('page_actions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/page_wrappers_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/page_wrappers_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_page_wrappers_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('page_wrappers_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/petitions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/petitions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_petitions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('petitions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/phone_change_logs_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/phone_change_logs_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_phone_change_logs_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('phone_change_logs_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/phone_dedupe_logs_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/phone_dedupe_logs_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_phone_dedupe_logs_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('phone_dedupe_logs_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/queries_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/queries_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_queries_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('queries_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/questions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/questions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_questions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('questions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/recurring_donations_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/recurring_donations_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_recurring_donations_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('recurring_donations_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/reports_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/reports_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_reports_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('reports_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/rsvps_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/rsvps_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_rsvps_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('rsvps_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/share_options_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/share_options_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_share_options_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('share_options_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/signatures_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/signatures_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_signatures_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('signatures_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/sms_message_activities_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/sms_message_activities_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_sms_message_activities_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('sms_message_activities_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/sms_messages_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/sms_messages_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_sms_messages_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('sms_messages_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/sms_status_logs_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/sms_status_logs_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_sms_status_logs_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('sms_status_logs_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/sms_statuses_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/sms_statuses_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_sms_statuses_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('sms_statuses_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/sms_unsubscriptions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/sms_unsubscriptions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_sms_unsubscriptions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('sms_unsubscriptions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/source_codes_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/source_codes_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_source_codes_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('source_codes_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/steps_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/steps_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_steps_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('steps_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/subscription_statuses_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/subscription_statuses_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_subscription_statuses_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('subscription_statuses_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/subscriptions_1_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/subscriptions_1_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_subscriptions_1_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('subscriptions_1_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/subscriptions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/subscriptions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_subscriptions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('subscriptions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/syndications_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/syndications_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_syndications_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('syndications_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/tag_syndications_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/tag_syndications_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_tag_syndications_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('tag_syndications_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/tags_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/tags_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_tags_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('tags_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/targets_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/targets_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_targets_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('targets_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/ticket_receipts_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/ticket_receipts_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_ticket_receipts_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('ticket_receipts_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/ticketed_events_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/ticketed_events_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_ticketed_events_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('ticketed_events_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/tickets_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/tickets_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_tickets_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('tickets_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/triggers_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/triggers_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_triggers_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('triggers_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/unsubscriptions_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/unsubscriptions_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_unsubscriptions_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('unsubscriptions_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/user_files_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/user_files_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_user_files_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('user_files_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/user_ladder_statuses_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/user_ladder_statuses_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_user_ladder_statuses_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('user_ladder_statuses_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/user_merge_logs_1_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/user_merge_logs_1_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_user_merge_logs_1_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('user_merge_logs_1_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/user_merge_logs_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/user_merge_logs_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_user_merge_logs_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('user_merge_logs_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/user_source_codes_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/user_source_codes_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_user_source_codes_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('user_source_codes_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/user_tags_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/user_tags_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_user_tags_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('user_tags_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/user_tickets_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/user_tickets_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_user_tickets_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('user_tickets_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/users_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/users_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_users_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('users_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/webhook_messages_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/webhook_messages_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_webhook_messages_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('webhook_messages_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/0_ctes/webhooks_ab4.sql
+++ b/dbt-cta/action_network/models/0_ctes/webhooks_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+SELECT * EXCEPT (rownum) FROM 
+(
+SELECT 
+    *,
+    ROW_NUMBER() OVER (PARTITION BY _airbyte_webhooks_hashid ORDER BY _airbyte_extracted_at desc) as rownum 
+from {{ ref('webhooks_ab3') }}
+)
+where rownum=1

--- a/dbt-cta/action_network/models/1_cta_full_refresh/action_keywords_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/action_keywords_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('action_keywords_ab3') }}
+-- depends_on: {{ ref('action_keywords_ab4') }}
 select
     id,
     text,
@@ -27,7 +27,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_action_keywords_hashid
-from {{ ref('action_keywords_ab3') }}
+from {{ ref('action_keywords_ab4') }}
 -- action_keywords from {{ source('cta', '_airbyte_raw_action_keywords') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/action_questions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/action_questions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('action_questions_ab3') }}
+-- depends_on: {{ ref('action_questions_ab4') }}
 select
     id,
     required,
@@ -28,7 +28,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_action_questions_hashid
-from {{ ref('action_questions_ab3') }}
+from {{ ref('action_questions_ab4') }}
 -- action_questions from {{ source('cta', '_airbyte_raw_action_questions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/actions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('actions_ab3') }}
+-- depends_on: {{ ref('actions_ab4') }}
 select
     id,
     source_id,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_actions_hashid
-from {{ ref('actions_ab3') }}
+from {{ ref('actions_ab4') }}
 -- actions from {{ source('cta', '_airbyte_raw_actions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/answers_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/answers_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('answers_ab3') }}
+-- depends_on: {{ ref('answers_ab4') }}
 select
     id,
     city,
@@ -41,7 +41,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_answers_hashid
-from {{ ref('answers_ab3') }}
+from {{ ref('answers_ab4') }}
 -- answers from {{ source('cta', '_airbyte_raw_answers') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/call_campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/call_campaigns_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('call_campaigns_ab3') }}
+-- depends_on: {{ ref('call_campaigns_ab4') }}
 select
     id,
     uuid,
@@ -76,7 +76,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_call_campaigns_hashid
-from {{ ref('call_campaigns_ab3') }}
+from {{ ref('call_campaigns_ab4') }}
 -- call_campaigns from {{ source('cta', '_airbyte_raw_call_campaigns') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/call_targets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/call_targets_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('call_targets_ab3') }}
+-- depends_on: {{ ref('call_targets_ab4') }}
 select
     id,
     uuid,
@@ -36,7 +36,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_call_targets_hashid
-from {{ ref('call_targets_ab3') }}
+from {{ ref('call_targets_ab4') }}
 -- call_targets from {{ source('cta', '_airbyte_raw_call_targets') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/calls_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/calls_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('calls_ab3') }}
+-- depends_on: {{ ref('calls_ab4') }}
 select
     id,
     city,
@@ -41,7 +41,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_calls_hashid
-from {{ ref('calls_ab3') }}
+from {{ ref('calls_ab4') }}
 -- calls from {{ source('cta', '_airbyte_raw_calls') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/campaigns_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('campaigns_ab3') }}
+-- depends_on: {{ ref('campaigns_ab4') }}
 select
     id,
     uuid,
@@ -39,7 +39,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_campaigns_hashid
-from {{ ref('campaigns_ab3') }}
+from {{ ref('campaigns_ab4') }}
 -- campaigns from {{ source('cta', '_airbyte_raw_campaigns') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/catalist_syncs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/catalist_syncs_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('catalist_syncs_ab3') }}
+-- depends_on: {{ ref('catalist_syncs_ab4') }}
 select
     id,
     token,
@@ -33,7 +33,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_catalist_syncs_hashid
-from {{ ref('catalist_syncs_ab3') }}
+from {{ ref('catalist_syncs_ab4') }}
 -- catalist_syncs from {{ source('cta', '_airbyte_raw_catalist_syncs') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/child_permissions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/child_permissions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('child_permissions_ab3') }}
+-- depends_on: {{ ref('child_permissions_ab4') }}
 select
     id,
     group_id,
@@ -27,7 +27,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_child_permissions_hashid
-from {{ ref('child_permissions_ab3') }}
+from {{ ref('child_permissions_ab4') }}
 -- child_permissions from {{ source('cta', '_airbyte_raw_child_permissions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/collections_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/collections_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('collections_ab3') }}
+-- depends_on: {{ ref('collections_ab4') }}
 select
     id,
     title,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_collections_hashid
-from {{ ref('collections_ab3') }}
+from {{ ref('collections_ab4') }}
 -- collections from {{ source('cta', '_airbyte_raw_collections') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/collections_groups_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/collections_groups_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('collections_groups_ab3') }}
+-- depends_on: {{ ref('collections_groups_ab4') }}
 select
     id,
     group_id,
@@ -25,7 +25,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_collections_groups_hashid
-from {{ ref('collections_groups_ab3') }}
+from {{ ref('collections_groups_ab4') }}
 -- collections_groups from {{ source('cta', '_airbyte_raw_collections_groups') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/comments_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/comments_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('comments_ab3') }}
+-- depends_on: {{ ref('comments_ab4') }}
 select
     id,
     title,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_comments_hashid
-from {{ ref('comments_ab3') }}
+from {{ ref('comments_ab4') }}
 -- comments from {{ source('cta', '_airbyte_raw_comments') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_field_syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_field_syndications_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('core_field_syndications_ab3') }}
+-- depends_on: {{ ref('core_field_syndications_ab4') }}
 select
     id,
     group_id,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_core_field_syndications_hashid
-from {{ ref('core_field_syndications_ab3') }}
+from {{ ref('core_field_syndications_ab4') }}
 -- core_field_syndications from {{ source('cta', '_airbyte_raw_core_field_syndications') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_field_timezones_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_field_timezones_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('core_field_timezones_ab3') }}
+-- depends_on: {{ ref('core_field_timezones_ab4') }}
 select
     id,
     timezone,
@@ -25,7 +25,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_core_field_timezones_hashid
-from {{ ref('core_field_timezones_ab3') }}
+from {{ ref('core_field_timezones_ab4') }}
 -- core_field_timezones from {{ source('cta', '_airbyte_raw_core_field_timezones') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('core_fields_ab3') }}
+-- depends_on: {{ ref('core_fields_ab4') }}
 select
     id,
     city,
@@ -37,7 +37,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_core_fields_hashid
-from {{ ref('core_fields_ab3') }}
+from {{ ref('core_fields_ab4') }}
 -- core_fields from {{ source('cta', '_airbyte_raw_core_fields') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_counties_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_counties_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('core_fields_counties_ab3') }}
+-- depends_on: {{ ref('core_fields_counties_ab4') }}
 select
     id,
     county_id,
@@ -23,7 +23,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_core_fields_counties_hashid
-from {{ ref('core_fields_counties_ab3') }}
+from {{ ref('core_fields_counties_ab4') }}
 -- core_fields_counties from {{ source('cta', '_airbyte_raw_core_fields_counties') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_ocdids_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_ocdids_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('core_fields_ocdids_ab3') }}
+-- depends_on: {{ ref('core_fields_ocdids_ab4') }}
 select
     id,
     ocdid_id,
@@ -23,7 +23,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_core_fields_ocdids_hashid
-from {{ ref('core_fields_ocdids_ab3') }}
+from {{ ref('core_fields_ocdids_ab4') }}
 -- core_fields_ocdids from {{ source('cta', '_airbyte_raw_core_fields_ocdids') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/counties_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/counties_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('counties_ab3') }}
+-- depends_on: {{ ref('counties_ab4') }}
 select
     id,
     created_at,
@@ -24,7 +24,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_counties_hashid
-from {{ ref('counties_ab3') }}
+from {{ ref('counties_ab4') }}
 -- counties from {{ source('cta', '_airbyte_raw_counties') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/deliveries_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/deliveries_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('deliveries_ab3') }}
+-- depends_on: {{ ref('deliveries_ab4') }}
 select
     id,
     city,
@@ -44,7 +44,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_deliveries_hashid
-from {{ ref('deliveries_ab3') }}
+from {{ ref('deliveries_ab4') }}
 -- deliveries from {{ source('cta', '_airbyte_raw_deliveries') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/delivery_targets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/delivery_targets_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('delivery_targets_ab3') }}
+-- depends_on: {{ ref('delivery_targets_ab4') }}
 select
     id,
     uuid,
@@ -41,7 +41,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_delivery_targets_hashid
-from {{ ref('delivery_targets_ab3') }}
+from {{ ref('delivery_targets_ab4') }}
 -- delivery_targets from {{ source('cta', '_airbyte_raw_delivery_targets') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donation_payments_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donation_payments_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('donation_payments_ab3') }}
+-- depends_on: {{ ref('donation_payments_ab4') }}
 select
     id,
     tip,
@@ -39,7 +39,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_donation_payments_hashid
-from {{ ref('donation_payments_ab3') }}
+from {{ ref('donation_payments_ab4') }}
 -- donation_payments from {{ source('cta', '_airbyte_raw_donation_payments') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donation_recipients_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donation_recipients_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('donation_recipients_ab3') }}
+-- depends_on: {{ ref('donation_recipients_ab4') }}
 select
     id,
     user_id,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_donation_recipients_hashid
-from {{ ref('donation_recipients_ab3') }}
+from {{ ref('donation_recipients_ab4') }}
 -- donation_recipients from {{ source('cta', '_airbyte_raw_donation_recipients') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donations_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('donations_ab3') }}
+-- depends_on: {{ ref('donations_ab4') }}
 select
     id,
     city,
@@ -48,7 +48,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_donations_hashid
-from {{ ref('donations_ab3') }}
+from {{ ref('donations_ab4') }}
 -- donations from {{ source('cta', '_airbyte_raw_donations') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donations_recurring_donations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donations_recurring_donations_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('donations_recurring_donations_ab3') }}
+-- depends_on: {{ ref('donations_recurring_donations_ab4') }}
 select
     id,
     created_at,
@@ -25,7 +25,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_donations_recurring_donations_hashid
-from {{ ref('donations_recurring_donations_ab3') }}
+from {{ ref('donations_recurring_donations_ab4') }}
 -- donations_recurring_donations from {{ source('cta', '_airbyte_raw_donations_recurring_donations') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_10_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_10_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_10_ab3') }}
+-- depends_on: {{ ref('email_activities_10_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_10_hashid
-from {{ ref('email_activities_10_ab3') }}
+from {{ ref('email_activities_10_ab4') }}
 -- email_activities_10 from {{ source('cta', '_airbyte_raw_email_activities_10') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_11_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_11_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_11_ab3') }}
+-- depends_on: {{ ref('email_activities_11_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_11_hashid
-from {{ ref('email_activities_11_ab3') }}
+from {{ ref('email_activities_11_ab4') }}
 -- email_activities_11 from {{ source('cta', '_airbyte_raw_email_activities_11') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_12_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_12_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_12_ab3') }}
+-- depends_on: {{ ref('email_activities_12_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_12_hashid
-from {{ ref('email_activities_12_ab3') }}
+from {{ ref('email_activities_12_ab4') }}
 -- email_activities_12 from {{ source('cta', '_airbyte_raw_email_activities_12') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_13_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_13_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_13_ab3') }}
+-- depends_on: {{ ref('email_activities_13_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_13_hashid
-from {{ ref('email_activities_13_ab3') }}
+from {{ ref('email_activities_13_ab4') }}
 -- email_activities_13 from {{ source('cta', '_airbyte_raw_email_activities_13') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_14_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_14_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_14_ab3') }}
+-- depends_on: {{ ref('email_activities_14_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_14_hashid
-from {{ ref('email_activities_14_ab3') }}
+from {{ ref('email_activities_14_ab4') }}
 -- email_activities_14 from {{ source('cta', '_airbyte_raw_email_activities_14') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_15_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_15_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_15_ab3') }}
+-- depends_on: {{ ref('email_activities_15_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_15_hashid
-from {{ ref('email_activities_15_ab3') }}
+from {{ ref('email_activities_15_ab4') }}
 -- email_activities_15 from {{ source('cta', '_airbyte_raw_email_activities_15') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_16_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_16_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_16_ab3') }}
+-- depends_on: {{ ref('email_activities_16_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_16_hashid
-from {{ ref('email_activities_16_ab3') }}
+from {{ ref('email_activities_16_ab4') }}
 -- email_activities_16 from {{ source('cta', '_airbyte_raw_email_activities_16') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_1_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_1_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_1_ab3') }}
+-- depends_on: {{ ref('email_activities_1_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_1_hashid
-from {{ ref('email_activities_1_ab3') }}
+from {{ ref('email_activities_1_ab4') }}
 -- email_activities_1 from {{ source('cta', '_airbyte_raw_email_activities_1') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_2_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_2_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_2_ab3') }}
+-- depends_on: {{ ref('email_activities_2_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_2_hashid
-from {{ ref('email_activities_2_ab3') }}
+from {{ ref('email_activities_2_ab4') }}
 -- email_activities_2 from {{ source('cta', '_airbyte_raw_email_activities_2') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_3_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_3_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_3_ab3') }}
+-- depends_on: {{ ref('email_activities_3_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_3_hashid
-from {{ ref('email_activities_3_ab3') }}
+from {{ ref('email_activities_3_ab4') }}
 -- email_activities_3 from {{ source('cta', '_airbyte_raw_email_activities_3') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_4_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_4_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_4_ab3') }}
+-- depends_on: {{ ref('email_activities_4_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_4_hashid
-from {{ ref('email_activities_4_ab3') }}
+from {{ ref('email_activities_4_ab4') }}
 -- email_activities_4 from {{ source('cta', '_airbyte_raw_email_activities_4') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_5_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_5_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_5_ab3') }}
+-- depends_on: {{ ref('email_activities_5_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_5_hashid
-from {{ ref('email_activities_5_ab3') }}
+from {{ ref('email_activities_5_ab4') }}
 -- email_activities_5 from {{ source('cta', '_airbyte_raw_email_activities_5') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_6_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_6_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_6_ab3') }}
+-- depends_on: {{ ref('email_activities_6_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_6_hashid
-from {{ ref('email_activities_6_ab3') }}
+from {{ ref('email_activities_6_ab4') }}
 -- email_activities_6 from {{ source('cta', '_airbyte_raw_email_activities_6') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_7_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_7_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_7_ab3') }}
+-- depends_on: {{ ref('email_activities_7_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_7_hashid
-from {{ ref('email_activities_7_ab3') }}
+from {{ ref('email_activities_7_ab4') }}
 -- email_activities_7 from {{ source('cta', '_airbyte_raw_email_activities_7') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_8_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_8_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_8_ab3') }}
+-- depends_on: {{ ref('email_activities_8_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_8_hashid
-from {{ ref('email_activities_8_ab3') }}
+from {{ ref('email_activities_8_ab4') }}
 -- email_activities_8 from {{ source('cta', '_airbyte_raw_email_activities_8') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_9_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_9_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_9_ab3') }}
+-- depends_on: {{ ref('email_activities_9_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_9_hashid
-from {{ ref('email_activities_9_ab3') }}
+from {{ ref('email_activities_9_ab4') }}
 -- email_activities_9 from {{ source('cta', '_airbyte_raw_email_activities_9') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_activities_ab3') }}
+-- depends_on: {{ ref('email_activities_ab4') }}
 select
     id,
     link_id,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_hashid
-from {{ ref('email_activities_ab3') }}
+from {{ ref('email_activities_ab4') }}
 -- email_activities from {{ source('cta', '_airbyte_raw_email_activities') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_campaign_members_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_campaign_members_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_campaign_members_ab3') }}
+-- depends_on: {{ ref('email_campaign_members_ab4') }}
 select
     id,
     email_id,
@@ -25,7 +25,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_campaign_members_hashid
-from {{ ref('email_campaign_members_ab3') }}
+from {{ ref('email_campaign_members_ab4') }}
 -- email_campaign_members from {{ source('cta', '_airbyte_raw_email_campaign_members') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_campaigns_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_campaigns_ab3') }}
+-- depends_on: {{ ref('email_campaigns_ab4') }}
 select
     id,
     name,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_campaigns_hashid
-from {{ ref('email_campaigns_ab3') }}
+from {{ ref('email_campaigns_ab4') }}
 -- email_campaigns from {{ source('cta', '_airbyte_raw_email_campaigns') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_fields_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_fields_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_fields_ab3') }}
+-- depends_on: {{ ref('email_fields_ab4') }}
 select
     id,
     text,
@@ -29,7 +29,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_fields_hashid
-from {{ ref('email_fields_ab3') }}
+from {{ ref('email_fields_ab4') }}
 -- email_fields from {{ source('cta', '_airbyte_raw_email_fields') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_stats_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_stats_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_stats_ab3') }}
+-- depends_on: {{ ref('email_stats_ab4') }}
 select
     id,
     stats,
@@ -28,7 +28,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_stats_hashid
-from {{ ref('email_stats_ab3') }}
+from {{ ref('email_stats_ab4') }}
 -- email_stats from {{ source('cta', '_airbyte_raw_email_stats') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_templates_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_templates_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_templates_ab3') }}
+-- depends_on: {{ ref('email_templates_ab4') }}
 select
     id,
     name,
@@ -37,7 +37,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_templates_hashid
-from {{ ref('email_templates_ab3') }}
+from {{ ref('email_templates_ab4') }}
 -- email_templates from {{ source('cta', '_airbyte_raw_email_templates') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_tests_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_tests_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('email_tests_ab3') }}
+-- depends_on: {{ ref('email_tests_ab4') }}
 select
     id,
     hours,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_tests_hashid
-from {{ ref('email_tests_ab3') }}
+from {{ ref('email_tests_ab4') }}
 -- email_tests from {{ source('cta', '_airbyte_raw_email_tests') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/emails_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/emails_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('emails_ab3') }}
+-- depends_on: {{ ref('emails_ab4') }}
 select
     id,
     {{ adapter.quote('to') }},
@@ -55,7 +55,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_emails_hashid
-from {{ ref('emails_ab3') }}
+from {{ ref('emails_ab4') }}
 -- emails from {{ source('cta', '_airbyte_raw_emails') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_invites_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_invites_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('event_campaign_invites_ab3') }}
+-- depends_on: {{ ref('event_campaign_invites_ab4') }}
 select
     id,
     status,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_event_campaign_invites_hashid
-from {{ ref('event_campaign_invites_ab3') }}
+from {{ ref('event_campaign_invites_ab4') }}
 -- event_campaign_invites from {{ source('cta', '_airbyte_raw_event_campaign_invites') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_uploads_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_uploads_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('event_campaign_uploads_ab3') }}
+-- depends_on: {{ ref('event_campaign_uploads_ab4') }}
 select
     id,
     {{ adapter.quote('rows') }},
@@ -32,7 +32,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_event_campaign_uploads_hashid
-from {{ ref('event_campaign_uploads_ab3') }}
+from {{ ref('event_campaign_uploads_ab4') }}
 -- event_campaign_uploads from {{ source('cta', '_airbyte_raw_event_campaign_uploads') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/event_campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/event_campaigns_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('event_campaigns_ab3') }}
+-- depends_on: {{ ref('event_campaigns_ab4') }}
 select
     id,
     uuid,
@@ -92,7 +92,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_event_campaigns_hashid
-from {{ ref('event_campaigns_ab3') }}
+from {{ ref('event_campaigns_ab4') }}
 -- event_campaigns from {{ source('cta', '_airbyte_raw_event_campaigns') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/events_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/events_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('events_ab3') }}
+-- depends_on: {{ ref('events_ab4') }}
 select
     id,
     city,
@@ -101,7 +101,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_events_hashid
-from {{ ref('events_ab3') }}
+from {{ ref('events_ab4') }}
 -- events from {{ source('cta', '_airbyte_raw_events') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/field_names_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/field_names_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('field_names_ab3') }}
+-- depends_on: {{ ref('field_names_ab4') }}
 select
     id,
     name,
@@ -32,7 +32,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_field_names_hashid
-from {{ ref('field_names_ab3') }}
+from {{ ref('field_names_ab4') }}
 -- field_names from {{ source('cta', '_airbyte_raw_field_names') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/field_names_groups_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/field_names_groups_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('field_names_groups_ab3') }}
+-- depends_on: {{ ref('field_names_groups_ab4') }}
 select
     id,
     hidden,
@@ -24,7 +24,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_field_names_groups_hashid
-from {{ ref('field_names_groups_ab3') }}
+from {{ ref('field_names_groups_ab4') }}
 -- field_names_groups from {{ source('cta', '_airbyte_raw_field_names_groups') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/field_values_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/field_values_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('field_values_ab3') }}
+-- depends_on: {{ ref('field_values_ab4') }}
 select
     id,
     uuid,
@@ -27,7 +27,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_field_values_hashid
-from {{ ref('field_values_ab3') }}
+from {{ ref('field_values_ab4') }}
 -- field_values from {{ source('cta', '_airbyte_raw_field_values') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/filter_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/filter_actions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('filter_actions_ab3') }}
+-- depends_on: {{ ref('filter_actions_ab4') }}
 select
     id,
     user_id,
@@ -28,7 +28,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_filter_actions_hashid
-from {{ ref('filter_actions_ab3') }}
+from {{ ref('filter_actions_ab4') }}
 -- filter_actions from {{ source('cta', '_airbyte_raw_filter_actions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/filters_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/filters_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('filters_ab3') }}
+-- depends_on: {{ ref('filters_ab4') }}
 select
     id,
     uuid,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_filters_hashid
-from {{ ref('filters_ab3') }}
+from {{ ref('filters_ab4') }}
 -- filters from {{ source('cta', '_airbyte_raw_filters') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/forms_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/forms_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('forms_ab3') }}
+-- depends_on: {{ ref('forms_ab4') }}
 select
     id,
     uuid,
@@ -74,7 +74,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_forms_hashid
-from {{ ref('forms_ab3') }}
+from {{ ref('forms_ab4') }}
 -- forms from {{ source('cta', '_airbyte_raw_forms') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/fundraisings_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/fundraisings_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('fundraisings_ab3') }}
+-- depends_on: {{ ref('fundraisings_ab4') }}
 select
     id,
     uuid,
@@ -74,7 +74,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_fundraisings_hashid
-from {{ ref('fundraisings_ab3') }}
+from {{ ref('fundraisings_ab4') }}
 -- fundraisings from {{ source('cta', '_airbyte_raw_fundraisings') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_actions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('group_growth_by_source_actions_ab3') }}
+-- depends_on: {{ ref('group_growth_by_source_actions_ab4') }}
 select
     id,
     end_at,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_group_growth_by_source_actions_hashid
-from {{ ref('group_growth_by_source_actions_ab3') }}
+from {{ ref('group_growth_by_source_actions_ab4') }}
 -- group_growth_by_source_actions from {{ source('cta', '_airbyte_raw_group_growth_by_source_actions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_codes_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_codes_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('group_growth_by_source_codes_ab3') }}
+-- depends_on: {{ ref('group_growth_by_source_codes_ab4') }}
 select
     id,
     end_at,
@@ -30,7 +30,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_group_growth_by_source_codes_hashid
-from {{ ref('group_growth_by_source_codes_ab3') }}
+from {{ ref('group_growth_by_source_codes_ab4') }}
 -- group_growth_by_source_codes from {{ source('cta', '_airbyte_raw_group_growth_by_source_codes') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/group_invites_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/group_invites_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('group_invites_ab3') }}
+-- depends_on: {{ ref('group_invites_ab4') }}
 select
     id,
     name,
@@ -28,7 +28,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_group_invites_hashid
-from {{ ref('group_invites_ab3') }}
+from {{ ref('group_invites_ab4') }}
 -- group_invites from {{ source('cta', '_airbyte_raw_group_invites') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/groups_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/groups_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('groups_ab3') }}
+-- depends_on: {{ ref('groups_ab4') }}
 select
     id,
     city,
@@ -108,7 +108,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_groups_hashid
-from {{ ref('groups_ab3') }}
+from {{ ref('groups_ab4') }}
 -- groups from {{ source('cta', '_airbyte_raw_groups') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/groups_syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/groups_syndications_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('groups_syndications_ab3') }}
+-- depends_on: {{ ref('groups_syndications_ab4') }}
 select
     id,
     read,
@@ -30,7 +30,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_groups_syndications_hashid
-from {{ ref('groups_syndications_ab3') }}
+from {{ ref('groups_syndications_ab4') }}
 -- groups_syndications from {{ source('cta', '_airbyte_raw_groups_syndications') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/groups_users_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/groups_users_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('groups_users_ab3') }}
+-- depends_on: {{ ref('groups_users_ab4') }}
 select
     id,
     hidden,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_groups_users_hashid
-from {{ ref('groups_users_ab3') }}
+from {{ ref('groups_users_ab4') }}
 -- groups_users from {{ source('cta', '_airbyte_raw_groups_users') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ladders_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ladders_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('ladders_ab3') }}
+-- depends_on: {{ ref('ladders_ab4') }}
 select
     id,
     notes,
@@ -33,7 +33,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_ladders_hashid
-from {{ ref('ladders_ab3') }}
+from {{ ref('ladders_ab4') }}
 -- ladders from {{ source('cta', '_airbyte_raw_ladders') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/letter_templates_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/letter_templates_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('letter_templates_ab3') }}
+-- depends_on: {{ ref('letter_templates_ab4') }}
 select
     id,
     tips,
@@ -32,7 +32,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_letter_templates_hashid
-from {{ ref('letter_templates_ab3') }}
+from {{ ref('letter_templates_ab4') }}
 -- letter_templates from {{ source('cta', '_airbyte_raw_letter_templates') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/letters_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/letters_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('letters_ab3') }}
+-- depends_on: {{ ref('letters_ab4') }}
 select
     id,
     uuid,
@@ -71,7 +71,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_letters_hashid
-from {{ ref('letters_ab3') }}
+from {{ ref('letters_ab4') }}
 -- letters from {{ source('cta', '_airbyte_raw_letters') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/lists_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/lists_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('lists_ab3') }}
+-- depends_on: {{ ref('lists_ab4') }}
 select
     id,
     title,
@@ -56,7 +56,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_lists_hashid
-from {{ ref('lists_ab3') }}
+from {{ ref('lists_ab4') }}
 -- lists from {{ source('cta', '_airbyte_raw_lists') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/locations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/locations_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('locations_ab3') }}
+-- depends_on: {{ ref('locations_ab4') }}
 select
     id,
     city,
@@ -35,7 +35,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_locations_hashid
-from {{ ref('locations_ab3') }}
+from {{ ref('locations_ab4') }}
 -- locations from {{ source('cta', '_airbyte_raw_locations') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/message_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/message_actions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('message_actions_ab3') }}
+-- depends_on: {{ ref('message_actions_ab4') }}
 select
     id,
     referrer,
@@ -28,7 +28,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_message_actions_hashid
-from {{ ref('message_actions_ab3') }}
+from {{ ref('message_actions_ab4') }}
 -- message_actions from {{ source('cta', '_airbyte_raw_message_actions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_fields_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_fields_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('mobile_message_fields_ab3') }}
+-- depends_on: {{ ref('mobile_message_fields_ab4') }}
 select
     id,
     text,
@@ -27,7 +27,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_mobile_message_fields_hashid
-from {{ ref('mobile_message_fields_ab3') }}
+from {{ ref('mobile_message_fields_ab4') }}
 -- mobile_message_fields from {{ source('cta', '_airbyte_raw_mobile_message_fields') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_stats_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_stats_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('mobile_message_stats_ab3') }}
+-- depends_on: {{ ref('mobile_message_stats_ab4') }}
 select
     id,
     stats,
@@ -28,7 +28,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_mobile_message_stats_hashid
-from {{ ref('mobile_message_stats_ab3') }}
+from {{ ref('mobile_message_stats_ab4') }}
 -- mobile_message_stats from {{ source('cta', '_airbyte_raw_mobile_message_stats') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/mobile_messages_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/mobile_messages_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('mobile_messages_ab3') }}
+-- depends_on: {{ ref('mobile_messages_ab4') }}
 select
     id,
     body,
@@ -42,7 +42,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_mobile_messages_hashid
-from {{ ref('mobile_messages_ab3') }}
+from {{ ref('mobile_messages_ab4') }}
 -- mobile_messages from {{ source('cta', '_airbyte_raw_mobile_messages') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/networks_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/networks_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('networks_ab3') }}
+-- depends_on: {{ ref('networks_ab4') }}
 select
     id,
     name,
@@ -34,7 +34,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_networks_hashid
-from {{ ref('networks_ab3') }}
+from {{ ref('networks_ab4') }}
 -- networks from {{ source('cta', '_airbyte_raw_networks') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/networks_users_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/networks_users_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('networks_users_ab3') }}
+-- depends_on: {{ ref('networks_users_ab4') }}
 select
     id,
     user_id,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_networks_users_hashid
-from {{ ref('networks_users_ab3') }}
+from {{ ref('networks_users_ab4') }}
 -- networks_users from {{ source('cta', '_airbyte_raw_networks_users') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/notification_settings_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/notification_settings_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('notification_settings_ab3') }}
+-- depends_on: {{ ref('notification_settings_ab4') }}
 select
     id,
     action_id,
@@ -27,7 +27,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_notification_settings_hashid
-from {{ ref('notification_settings_ab3') }}
+from {{ ref('notification_settings_ab4') }}
 -- notification_settings from {{ source('cta', '_airbyte_raw_notification_settings') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ocdids_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ocdids_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('ocdids_ab3') }}
+-- depends_on: {{ ref('ocdids_ab4') }}
 select
     id,
     created_at,
@@ -25,7 +25,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_ocdids_hashid
-from {{ ref('ocdids_ab3') }}
+from {{ ref('ocdids_ab4') }}
 -- ocdids from {{ source('cta', '_airbyte_raw_ocdids') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/page_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/page_actions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('page_actions_ab3') }}
+-- depends_on: {{ ref('page_actions_ab4') }}
 select
     id,
     action_id,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_page_actions_hashid
-from {{ ref('page_actions_ab3') }}
+from {{ ref('page_actions_ab4') }}
 -- page_actions from {{ source('cta', '_airbyte_raw_page_actions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/page_wrappers_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/page_wrappers_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('page_wrappers_ab3') }}
+-- depends_on: {{ ref('page_wrappers_ab4') }}
 select
     id,
     name,
@@ -34,7 +34,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_page_wrappers_hashid
-from {{ ref('page_wrappers_ab3') }}
+from {{ ref('page_wrappers_ab4') }}
 -- page_wrappers from {{ source('cta', '_airbyte_raw_page_wrappers') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/petitions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/petitions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('petitions_ab3') }}
+-- depends_on: {{ ref('petitions_ab4') }}
 select
     id,
     uuid,
@@ -77,7 +77,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_petitions_hashid
-from {{ ref('petitions_ab3') }}
+from {{ ref('petitions_ab4') }}
 -- petitions from {{ source('cta', '_airbyte_raw_petitions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/phone_change_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/phone_change_logs_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('phone_change_logs_ab3') }}
+-- depends_on: {{ ref('phone_change_logs_ab4') }}
 select
     id,
     user_id,
@@ -30,7 +30,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_phone_change_logs_hashid
-from {{ ref('phone_change_logs_ab3') }}
+from {{ ref('phone_change_logs_ab4') }}
 -- phone_change_logs from {{ source('cta', '_airbyte_raw_phone_change_logs') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/phone_dedupe_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/phone_dedupe_logs_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('phone_dedupe_logs_ab3') }}
+-- depends_on: {{ ref('phone_dedupe_logs_ab4') }}
 select
     id,
     phone,
@@ -30,7 +30,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_phone_dedupe_logs_hashid
-from {{ ref('phone_dedupe_logs_ab3') }}
+from {{ ref('phone_dedupe_logs_ab4') }}
 -- phone_dedupe_logs from {{ source('cta', '_airbyte_raw_phone_dedupe_logs') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/queries_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/queries_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('queries_ab3') }}
+-- depends_on: {{ ref('queries_ab4') }}
 select
     id,
     name,
@@ -29,7 +29,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_queries_hashid
-from {{ ref('queries_ab3') }}
+from {{ ref('queries_ab4') }}
 -- queries from {{ source('cta', '_airbyte_raw_queries') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/questions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/questions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('questions_ab3') }}
+-- depends_on: {{ ref('questions_ab4') }}
 select
     id,
     key,
@@ -36,7 +36,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_questions_hashid
-from {{ ref('questions_ab3') }}
+from {{ ref('questions_ab4') }}
 -- questions from {{ source('cta', '_airbyte_raw_questions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/recurring_donations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/recurring_donations_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('recurring_donations_ab3') }}
+-- depends_on: {{ ref('recurring_donations_ab4') }}
 select
     id,
     status,
@@ -30,7 +30,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_recurring_donations_hashid
-from {{ ref('recurring_donations_ab3') }}
+from {{ ref('recurring_donations_ab4') }}
 -- recurring_donations from {{ source('cta', '_airbyte_raw_recurring_donations') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/reports_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/reports_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('reports_ab3') }}
+-- depends_on: {{ ref('reports_ab4') }}
 select
     id,
     name,
@@ -40,7 +40,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_reports_hashid
-from {{ ref('reports_ab3') }}
+from {{ ref('reports_ab4') }}
 -- reports from {{ source('cta', '_airbyte_raw_reports') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/rsvps_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/rsvps_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('rsvps_ab3') }}
+-- depends_on: {{ ref('rsvps_ab4') }}
 select
     id,
     city,
@@ -42,7 +42,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_rsvps_hashid
-from {{ ref('rsvps_ab3') }}
+from {{ ref('rsvps_ab4') }}
 -- rsvps from {{ source('cta', '_airbyte_raw_rsvps') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/share_options_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/share_options_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('share_options_ab3') }}
+-- depends_on: {{ ref('share_options_ab4') }}
 select
     id,
     {{ adapter.quote('from') }},
@@ -49,7 +49,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_share_options_hashid
-from {{ ref('share_options_ab3') }}
+from {{ ref('share_options_ab4') }}
 -- share_options from {{ source('cta', '_airbyte_raw_share_options') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/signatures_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/signatures_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('signatures_ab3') }}
+-- depends_on: {{ ref('signatures_ab4') }}
 select
     id,
     city,
@@ -41,7 +41,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_signatures_hashid
-from {{ ref('signatures_ab3') }}
+from {{ ref('signatures_ab4') }}
 -- signatures from {{ source('cta', '_airbyte_raw_signatures') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_message_activities_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_message_activities_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('sms_message_activities_ab3') }}
+-- depends_on: {{ ref('sms_message_activities_ab4') }}
 select
     id,
     link,
@@ -34,7 +34,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_sms_message_activities_hashid
-from {{ ref('sms_message_activities_ab3') }}
+from {{ ref('sms_message_activities_ab4') }}
 -- sms_message_activities from {{ source('cta', '_airbyte_raw_sms_message_activities') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_messages_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_messages_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('sms_messages_ab3') }}
+-- depends_on: {{ ref('sms_messages_ab4') }}
 select
     id,
     {{ adapter.quote('to') }},
@@ -32,7 +32,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_sms_messages_hashid
-from {{ ref('sms_messages_ab3') }}
+from {{ ref('sms_messages_ab4') }}
 -- sms_messages from {{ source('cta', '_airbyte_raw_sms_messages') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_status_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_status_logs_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('sms_status_logs_ab3') }}
+-- depends_on: {{ ref('sms_status_logs_ab4') }}
 select
     id,
     status,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_sms_status_logs_hashid
-from {{ ref('sms_status_logs_ab3') }}
+from {{ ref('sms_status_logs_ab4') }}
 -- sms_status_logs from {{ source('cta', '_airbyte_raw_sms_status_logs') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_statuses_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_statuses_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('sms_statuses_ab3') }}
+-- depends_on: {{ ref('sms_statuses_ab4') }}
 select
     id,
     status,
@@ -30,7 +30,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_sms_statuses_hashid
-from {{ ref('sms_statuses_ab3') }}
+from {{ ref('sms_statuses_ab4') }}
 -- sms_statuses from {{ source('cta', '_airbyte_raw_sms_statuses') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_unsubscriptions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_unsubscriptions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('sms_unsubscriptions_ab3') }}
+-- depends_on: {{ ref('sms_unsubscriptions_ab4') }}
 select
     id,
     reason,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_sms_unsubscriptions_hashid
-from {{ ref('sms_unsubscriptions_ab3') }}
+from {{ ref('sms_unsubscriptions_ab4') }}
 -- sms_unsubscriptions from {{ source('cta', '_airbyte_raw_sms_unsubscriptions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/source_codes_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/source_codes_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('source_codes_ab3') }}
+-- depends_on: {{ ref('source_codes_ab4') }}
 select
     id,
     owner_id,
@@ -26,7 +26,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_source_codes_hashid
-from {{ ref('source_codes_ab3') }}
+from {{ ref('source_codes_ab4') }}
 -- source_codes from {{ source('cta', '_airbyte_raw_source_codes') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/steps_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/steps_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('steps_ab3') }}
+-- depends_on: {{ ref('steps_ab4') }}
 select
     id,
     uuid,
@@ -29,7 +29,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_steps_hashid
-from {{ ref('steps_ab3') }}
+from {{ ref('steps_ab4') }}
 -- steps from {{ source('cta', '_airbyte_raw_steps') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/subscription_statuses_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/subscription_statuses_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('subscription_statuses_ab3') }}
+-- depends_on: {{ ref('subscription_statuses_ab4') }}
 select
     id,
     status,
@@ -30,7 +30,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_subscription_statuses_hashid
-from {{ ref('subscription_statuses_ab3') }}
+from {{ ref('subscription_statuses_ab4') }}
 -- subscription_statuses from {{ source('cta', '_airbyte_raw_subscription_statuses') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_1_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_1_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('subscriptions_1_ab3') }}
+-- depends_on: {{ ref('subscriptions_1_ab4') }}
 select
     id,
     amount,
@@ -39,7 +39,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_subscriptions_1_hashid
-from {{ ref('subscriptions_1_ab3') }}
+from {{ ref('subscriptions_1_ab4') }}
 -- subscriptions_1 from {{ source('cta', '_airbyte_raw_subscriptions_1') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('subscriptions_ab3') }}
+-- depends_on: {{ ref('subscriptions_ab4') }}
 select
     id,
     amount,
@@ -39,7 +39,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_subscriptions_hashid
-from {{ ref('subscriptions_ab3') }}
+from {{ ref('subscriptions_ab4') }}
 -- subscriptions from {{ source('cta', '_airbyte_raw_subscriptions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/syndications_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('syndications_ab3') }}
+-- depends_on: {{ ref('syndications_ab4') }}
 select
     id,
     uuid,
@@ -43,7 +43,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_syndications_hashid
-from {{ ref('syndications_ab3') }}
+from {{ ref('syndications_ab4') }}
 -- syndications from {{ source('cta', '_airbyte_raw_syndications') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/tag_syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/tag_syndications_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('tag_syndications_ab3') }}
+-- depends_on: {{ ref('tag_syndications_ab4') }}
 select
     id,
     tag_id,
@@ -28,7 +28,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_tag_syndications_hashid
-from {{ ref('tag_syndications_ab3') }}
+from {{ ref('tag_syndications_ab4') }}
 -- tag_syndications from {{ source('cta', '_airbyte_raw_tag_syndications') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/tags_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/tags_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('tags_ab3') }}
+-- depends_on: {{ ref('tags_ab4') }}
 select
     id,
     name,
@@ -29,7 +29,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_tags_hashid
-from {{ ref('tags_ab3') }}
+from {{ ref('tags_ab4') }}
 -- tags from {{ source('cta', '_airbyte_raw_tags') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/targets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/targets_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('targets_ab3') }}
+-- depends_on: {{ ref('targets_ab4') }}
 select
     id,
     title,
@@ -33,7 +33,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_targets_hashid
-from {{ ref('targets_ab3') }}
+from {{ ref('targets_ab4') }}
 -- targets from {{ source('cta', '_airbyte_raw_targets') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ticket_receipts_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ticket_receipts_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('ticket_receipts_ab3') }}
+-- depends_on: {{ ref('ticket_receipts_ab4') }}
 select
     id,
     city,
@@ -47,7 +47,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_ticket_receipts_hashid
-from {{ ref('ticket_receipts_ab3') }}
+from {{ ref('ticket_receipts_ab4') }}
 -- ticket_receipts from {{ source('cta', '_airbyte_raw_ticket_receipts') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ticketed_events_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ticketed_events_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('ticketed_events_ab3') }}
+-- depends_on: {{ ref('ticketed_events_ab4') }}
 select
     id,
     city,
@@ -84,7 +84,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_ticketed_events_hashid
-from {{ ref('ticketed_events_ab3') }}
+from {{ ref('ticketed_events_ab4') }}
 -- ticketed_events from {{ source('cta', '_airbyte_raw_ticketed_events') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/tickets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/tickets_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('tickets_ab3') }}
+-- depends_on: {{ ref('tickets_ab4') }}
 select
     id,
     price,
@@ -30,7 +30,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_tickets_hashid
-from {{ ref('tickets_ab3') }}
+from {{ ref('tickets_ab4') }}
 -- tickets from {{ source('cta', '_airbyte_raw_tickets') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/triggers_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/triggers_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('triggers_ab3') }}
+-- depends_on: {{ ref('triggers_ab4') }}
 select
     id,
     uuid,
@@ -34,7 +34,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_triggers_hashid
-from {{ ref('triggers_ab3') }}
+from {{ ref('triggers_ab4') }}
 -- triggers from {{ source('cta', '_airbyte_raw_triggers') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/unsubscriptions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/unsubscriptions_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('unsubscriptions_ab3') }}
+-- depends_on: {{ ref('unsubscriptions_ab4') }}
 select
     id,
     reason,
@@ -36,7 +36,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_unsubscriptions_hashid
-from {{ ref('unsubscriptions_ab3') }}
+from {{ ref('unsubscriptions_ab4') }}
 -- unsubscriptions from {{ source('cta', '_airbyte_raw_unsubscriptions') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_files_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_files_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('user_files_ab3') }}
+-- depends_on: {{ ref('user_files_ab4') }}
 select
     id,
     name,
@@ -36,7 +36,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_files_hashid
-from {{ ref('user_files_ab3') }}
+from {{ ref('user_files_ab4') }}
 -- user_files from {{ source('cta', '_airbyte_raw_user_files') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_ladder_statuses_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_ladder_statuses_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('user_ladder_statuses_ab3') }}
+-- depends_on: {{ ref('user_ladder_statuses_ab4') }}
 select
     id,
     rung_id,
@@ -29,7 +29,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_ladder_statuses_hashid
-from {{ ref('user_ladder_statuses_ab3') }}
+from {{ ref('user_ladder_statuses_ab4') }}
 -- user_ladder_statuses from {{ source('cta', '_airbyte_raw_user_ladder_statuses') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_1_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_1_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('user_merge_logs_1_ab3') }}
+-- depends_on: {{ ref('user_merge_logs_1_ab4') }}
 select
     id,
     list_id,
@@ -29,7 +29,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_merge_logs_1_hashid
-from {{ ref('user_merge_logs_1_ab3') }}
+from {{ ref('user_merge_logs_1_ab4') }}
 -- user_merge_logs_1 from {{ source('cta', '_airbyte_raw_user_merge_logs_1') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('user_merge_logs_ab3') }}
+-- depends_on: {{ ref('user_merge_logs_ab4') }}
 select
     id,
     list_id,
@@ -29,7 +29,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_merge_logs_hashid
-from {{ ref('user_merge_logs_ab3') }}
+from {{ ref('user_merge_logs_ab4') }}
 -- user_merge_logs from {{ source('cta', '_airbyte_raw_user_merge_logs') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_source_codes_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_source_codes_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('user_source_codes_ab3') }}
+-- depends_on: {{ ref('user_source_codes_ab4') }}
 select
     id,
     user_id,
@@ -28,7 +28,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_source_codes_hashid
-from {{ ref('user_source_codes_ab3') }}
+from {{ ref('user_source_codes_ab4') }}
 -- user_source_codes from {{ source('cta', '_airbyte_raw_user_source_codes') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_tags_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_tags_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('user_tags_ab3') }}
+-- depends_on: {{ ref('user_tags_ab4') }}
 select
     id,
     uuid,
@@ -27,7 +27,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_tags_hashid
-from {{ ref('user_tags_ab3') }}
+from {{ ref('user_tags_ab4') }}
 -- user_tags from {{ source('cta', '_airbyte_raw_user_tags') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_tickets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_tickets_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('user_tickets_ab3') }}
+-- depends_on: {{ ref('user_tickets_ab4') }}
 select
     id,
     amount,
@@ -28,7 +28,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_tickets_hashid
-from {{ ref('user_tickets_ab3') }}
+from {{ ref('user_tickets_ab4') }}
 -- user_tickets from {{ source('cta', '_airbyte_raw_user_tickets') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/users_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/users_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('users_ab3') }}
+-- depends_on: {{ ref('users_ab4') }}
 select
     id,
     info,
@@ -63,7 +63,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_users_hashid
-from {{ ref('users_ab3') }}
+from {{ ref('users_ab4') }}
 -- users from {{ source('cta', '_airbyte_raw_users') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/webhook_messages_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/webhook_messages_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('webhook_messages_ab3') }}
+-- depends_on: {{ ref('webhook_messages_ab4') }}
 select
     id,
     error,
@@ -31,7 +31,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_webhook_messages_hashid
-from {{ ref('webhook_messages_ab3') }}
+from {{ ref('webhook_messages_ab4') }}
 -- webhook_messages from {{ source('cta', '_airbyte_raw_webhook_messages') }}
 
 {% if is_incremental() %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/webhooks_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/webhooks_base.sql
@@ -14,7 +14,7 @@
     unique_key = "_airbyte_ab_id"
 ) }}
 -- Final base SQL model
--- depends_on: {{ ref('webhooks_ab3') }}
+-- depends_on: {{ ref('webhooks_ab4') }}
 select
     id,
     name,
@@ -27,7 +27,7 @@ select
     _airbyte_emitted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_webhooks_hashid
-from {{ ref('webhooks_ab3') }}
+from {{ ref('webhooks_ab4') }}
 -- webhooks from {{ source('cta', '_airbyte_raw_webhooks') }}
 
 {% if is_incremental() %}


### PR DESCRIPTION
We should add these CTEs to all of our dbt projects, but this change is a priority for Action Network data because the Airbyte source connector (Redshift) sometimes only does a partial sync and needs to restart, resulting in duplicate rows in the raw tables that need to be handled downstream (via these models).