### PR TITLE
[DE-634] sprout social: add `customer_profile_id` to post analytics and correctly parse json fields in profile analytics

### DIFF
--- a/dbt-cta/sprout_social/models/0_ctes/facebook_post_analytics_ab1.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/facebook_post_analytics_ab1.sql
@@ -10,6 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
+    customer_profile_id,
     created_time,
     perma_link,
     text,

--- a/dbt-cta/sprout_social/models/0_ctes/facebook_profile_analytics_ab1.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/facebook_profile_analytics_ab1.sql
@@ -17,9 +17,9 @@ select
     metrics,
     -- metrics fields unnested:
     {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_count'], ['lifetime_snapshot.followers_count']) }} as lifetime_snapshot_followers_count,
-    {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_by_country'], ['lifetime_snapshot.followers_by_country']) }} as lifetime_snapshot_followers_by_country,
-    {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_by_age_gender'], ['lifetime_snapshot.followers_by_age_gender']) }} as lifetime_snapshot_followers_by_age_gender,
-    {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_by_city'], ['lifetime_snapshot.followers_by_city']) }} as lifetime_snapshot_followers_by_city,
+    json_extract(metrics, "$['lifetime_snapshot.followers_by_country']") as followers_by_country,
+    json_extract(metrics, "$['lifetime_snapshot.followers_by_age_gender']") as followers_by_age_gender,
+    json_extract(metrics, "$['lifetime_snapshot.followers_by_city']") as followers_by_city,
     {{ json_extract_scalar('metrics', ['net_follower_growth'], ['net_follower_growth']) }} as net_follower_growth,
     {{ json_extract_scalar('metrics', ['followers_gained'], ['followers_gained']) }} as followers_gained,
     {{ json_extract_scalar('metrics', ['followers_gained_organic'], ['followers_gained_organic']) }} as followers_gained_organic,
@@ -100,6 +100,6 @@ select
     {{ json_extract_scalar('metrics', ['video_views_10s_repeat'], ['video_views_10s_repeat']) }} as video_views_10s_repeat,
     {{ json_extract_scalar('metrics', ['video_views_10s_unique'], ['video_views_10s_unique']) }} as video_views_10s_unique,
     {{ json_extract_scalar('metrics', ['posts_sent_count'], ['posts_sent_count']) }} as posts_sent_count,
-    {{ json_extract('metrics', ['posts_sent_by_post_type'], ['posts_sent_by_post_type']) }} as posts_sent_by_post_type,
-    {{ json_extract('metrics', ['posts_sent_by_content_type'], ['posts_sent_by_content_type']) }} as posts_sent_by_content_type
+    json_extract(metrics, '$.posts_sent_by_post_type') as posts_sent_by_post_type,
+    json_extract(metrics, '$.posts_sent_by_content_type') as posts_sent_by_content_type
 from {{ source('cta', 'facebook_profile_analytics') }}

--- a/dbt-cta/sprout_social/models/0_ctes/facebook_profile_analytics_ab1.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/facebook_profile_analytics_ab1.sql
@@ -100,6 +100,6 @@ select
     {{ json_extract_scalar('metrics', ['video_views_10s_repeat'], ['video_views_10s_repeat']) }} as video_views_10s_repeat,
     {{ json_extract_scalar('metrics', ['video_views_10s_unique'], ['video_views_10s_unique']) }} as video_views_10s_unique,
     {{ json_extract_scalar('metrics', ['posts_sent_count'], ['posts_sent_count']) }} as posts_sent_count,
-    {{ json_extract_scalar('metrics', ['posts_sent_by_post_type'], ['posts_sent_by_post_type']) }} as posts_sent_by_post_type,
-    {{ json_extract_scalar('metrics', ['posts_sent_by_content_type'], ['posts_sent_by_content_type']) }} as posts_sent_by_content_type
+    {{ json_extract('metrics', ['posts_sent_by_post_type'], ['posts_sent_by_post_type']) }} as posts_sent_by_post_type,
+    {{ json_extract('metrics', ['posts_sent_by_content_type'], ['posts_sent_by_content_type']) }} as posts_sent_by_content_type
 from {{ source('cta', 'facebook_profile_analytics') }}

--- a/dbt-cta/sprout_social/models/0_ctes/facebook_profile_analytics_ab2.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/facebook_profile_analytics_ab2.sql
@@ -12,9 +12,6 @@ select
     'customer_profile_id',
     'reporting_period_day',
     'lifetime_snapshot_followers_count',
-    'lifetime_snapshot_followers_by_country',
-    'lifetime_snapshot_followers_by_age_gender',
-    'lifetime_snapshot_followers_by_city',
     'net_follower_growth',
     'followers_gained',
     'followers_gained_organic',
@@ -95,7 +92,5 @@ select
     'video_views_10s_repeat',
     'video_views_10s_unique',
     'posts_sent_count',
-    'posts_sent_by_post_type',
-    'posts_sent_by_content_type'
     ]) }} as _airbyte_facebook_profile_analytics_hashid
 from {{ ref('facebook_profile_analytics_ab1') }}

--- a/dbt-cta/sprout_social/models/0_ctes/instagram_post_analytics_ab1.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/instagram_post_analytics_ab1.sql
@@ -10,6 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
+    customer_profile_id,
     created_time,
     perma_link,
     text,

--- a/dbt-cta/sprout_social/models/0_ctes/instagram_profile_analytics_ab1.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/instagram_profile_analytics_ab1.sql
@@ -17,9 +17,9 @@ select
     metrics,
     -- metrics fields unnested:
     {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_count'], ['lifetime_snapshot.followers_count']) }} as lifetime_snapshot_followers_count,
-    {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_by_country'], ['lifetime_snapshot.followers_by_country']) }} as lifetime_snapshot_followers_by_country,
-    {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_by_age_gender'], ['lifetime_snapshot.followers_by_age_gender']) }} as lifetime_snapshot_followers_by_age_gender,
-    {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_by_city'], ['lifetime_snapshot.followers_by_city']) }} as lifetime_snapshot_followers_by_city,
+    json_extract(metrics, "$['lifetime_snapshot.followers_by_country']") as followers_by_country,
+    json_extract(metrics, "$['lifetime_snapshot.followers_by_age_gender']") as followers_by_age_gender,
+    json_extract(metrics, "$['lifetime_snapshot.followers_by_city']") as followers_by_city,
     {{ json_extract_scalar('metrics', ['lifetime_snapshot.following_count'], ['lifetime_snapshot.following_count']) }} as lifetime_snapshot_following_count,
     {{ json_extract_scalar('metrics', ['net_follower_growth'], ['net_follower_growth']) }} as net_follower_growth,
     {{ json_extract_scalar('metrics', ['followers_gained'], ['followers_gained']) }} as followers_gained,
@@ -40,6 +40,6 @@ select
     {{ json_extract_scalar('metrics', ['text_message_clicks'], ['text_message_clicks']) }} as text_message_clicks,
     {{ json_extract_scalar('metrics', ['website_clicks'], ['website_clicks']) }} as website_clicks,
     {{ json_extract_scalar('metrics', ['posts_sent_count'], ['posts_sent_count']) }} as posts_sent_count,
-    {{ json_extract('metrics', ['posts_sent_by_post_type'], ['posts_sent_by_post_type']) }} as posts_sent_by_post_type,
-    {{ json_extract('metrics', ['posts_sent_by_content_type'], ['posts_sent_by_content_type']) }} as posts_sent_by_content_type
+    json_extract(metrics, '$.posts_sent_by_post_type') as posts_sent_by_post_type,
+    json_extract(metrics, '$.posts_sent_by_content_type') as posts_sent_by_content_type
 from {{ source('cta', 'instagram_profile_analytics') }}

--- a/dbt-cta/sprout_social/models/0_ctes/instagram_profile_analytics_ab1.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/instagram_profile_analytics_ab1.sql
@@ -40,6 +40,6 @@ select
     {{ json_extract_scalar('metrics', ['text_message_clicks'], ['text_message_clicks']) }} as text_message_clicks,
     {{ json_extract_scalar('metrics', ['website_clicks'], ['website_clicks']) }} as website_clicks,
     {{ json_extract_scalar('metrics', ['posts_sent_count'], ['posts_sent_count']) }} as posts_sent_count,
-    {{ json_extract_scalar('metrics', ['posts_sent_by_post_type'], ['posts_sent_by_post_type']) }} as posts_sent_by_post_type,
-    {{ json_extract_scalar('metrics', ['posts_sent_by_content_type'], ['posts_sent_by_content_type']) }} as posts_sent_by_content_type
+    {{ json_extract('metrics', ['posts_sent_by_post_type'], ['posts_sent_by_post_type']) }} as posts_sent_by_post_type,
+    {{ json_extract('metrics', ['posts_sent_by_content_type'], ['posts_sent_by_content_type']) }} as posts_sent_by_content_type
 from {{ source('cta', 'instagram_profile_analytics') }}

--- a/dbt-cta/sprout_social/models/0_ctes/instagram_profile_analytics_ab2.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/instagram_profile_analytics_ab2.sql
@@ -12,9 +12,6 @@ select
     'customer_profile_id',
     'reporting_period_day',
     'lifetime_snapshot_followers_count',
-    'lifetime_snapshot_followers_by_country',
-    'lifetime_snapshot_followers_by_age_gender',
-    'lifetime_snapshot_followers_by_city',
     'lifetime_snapshot_following_count',
     'net_follower_growth',
     'followers_gained',
@@ -35,7 +32,5 @@ select
     'text_message_clicks',
     'website_clicks',
     'posts_sent_count',
-    'posts_sent_by_post_type',
-    'posts_sent_by_content_type',
     ]) }} as _airbyte_instagram_profile_analytics_hashid
 from {{ ref('instagram_profile_analytics_ab1') }}

--- a/dbt-cta/sprout_social/models/0_ctes/tiktok_post_analytics_ab1.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/tiktok_post_analytics_ab1.sql
@@ -10,6 +10,7 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     _airbyte_meta,
+    customer_profile_id,
     created_time,
     perma_link,
     text,

--- a/dbt-cta/sprout_social/models/0_ctes/tiktok_profile_analytics_ab1.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/tiktok_profile_analytics_ab1.sql
@@ -18,8 +18,8 @@ select
     -- metrics fields unnested:
     {{ json_extract_scalar('metrics', ['lifetime.likes'], ['lifetime.likes']) }} as lifetime_likes,
     {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_count'], ['lifetime_snapshot.followers_count']) }} as lifetime_snapshot_followers_count,
-    {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_by_country'], ['lifetime_snapshot.followers_by_country']) }} as lifetime_snapshot_followers_by_country,
-    {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_by_gender'], ['lifetime_snapshot.followers_by_gender']) }} as lifetime_snapshot_followers_by_gender,
+    json_extract(metrics, "$['lifetime_snapshot.followers_by_country']") as followers_by_country,
+    json_extract(metrics, "$['lifetime_snapshot.followers_by_gender']") as followers_by_gender,
     {{ json_extract_scalar('metrics', ['lifetime_snapshot.followers_online'], ['lifetime_snapshot.followers_online']) }} as lifetime_snapshot_followers_online,
     {{ json_extract_scalar('metrics', ['net_follower_growth'], ['net_follower_growth']) }} as net_follower_growth,
     {{ json_extract_scalar('metrics', ['impressions'], ['impressions']) }} as impressions,
@@ -29,5 +29,5 @@ select
     {{ json_extract_scalar('metrics', ['shares_count_total'], ['shares_count_total']) }} as shares_count_total,
     {{ json_extract_scalar('metrics', ['likes_total'], ['likes_total']) }} as likes_total,
     {{ json_extract_scalar('metrics', ['posts_sent_count'], ['posts_sent_count']) }} as posts_sent_count,
-    {{ json_extract('metrics', ['posts_sent_by_post_type'], ['posts_sent_by_post_type']) }} as posts_sent_by_post_type
+    json_extract(metrics, '$.posts_sent_by_post_type') as posts_sent_by_post_type
 from {{ source('cta', 'tiktok_profile_analytics') }}

--- a/dbt-cta/sprout_social/models/0_ctes/tiktok_profile_analytics_ab1.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/tiktok_profile_analytics_ab1.sql
@@ -29,5 +29,5 @@ select
     {{ json_extract_scalar('metrics', ['shares_count_total'], ['shares_count_total']) }} as shares_count_total,
     {{ json_extract_scalar('metrics', ['likes_total'], ['likes_total']) }} as likes_total,
     {{ json_extract_scalar('metrics', ['posts_sent_count'], ['posts_sent_count']) }} as posts_sent_count,
-    {{ json_extract_scalar('metrics', ['posts_sent_by_post_type'], ['posts_sent_by_post_type']) }} as posts_sent_by_post_type
+    {{ json_extract('metrics', ['posts_sent_by_post_type'], ['posts_sent_by_post_type']) }} as posts_sent_by_post_type
 from {{ source('cta', 'tiktok_profile_analytics') }}

--- a/dbt-cta/sprout_social/models/0_ctes/tiktok_profile_analytics_ab2.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/tiktok_profile_analytics_ab2.sql
@@ -13,8 +13,6 @@ select
     'reporting_period_day',
     'lifetime_likes',
     'lifetime_snapshot_followers_count',
-    'lifetime_snapshot_followers_by_country',
-    'lifetime_snapshot_followers_by_gender',
     'lifetime_snapshot_followers_online',
     'net_follower_growth',
     'impressions',
@@ -24,6 +22,5 @@ select
     'shares_count_total',
     'likes_total',
     'posts_sent_count',
-    'posts_sent_by_post_type',
     ]) }} as _airbyte_tiktok_profile_analytics_hashid
 from {{ ref('tiktok_profile_analytics_ab1') }}


### PR DESCRIPTION
These dbt changes accompany recent changes to Sprout Social sync to:

1 - start including `customer_profile_id` in post analytics tables, and 
2 - correctly parse JSON fields in the profile analytics tables.