### PR TITLE
feat: enable `full_refresh` for partner models

### DIFF
--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -43,6 +43,7 @@ models:
         - partner
       +materialized: materialized_view
       +auto_refresh: false
+      +full_refresh: true
       +refresh_interval_minutes: 1440
       +grant_access_to:
         - project: "{{ env_var('CTA_PROJECT_ID') }}"


### PR DESCRIPTION
To test this in dev, I did the following:

1 - ran dbt locally for `partner_a_sprout_social` with full-refresh:

```shell
export CTA_PROJECT_ID='dev3869c056' 
export CTA_DATASET_ID='partner_a_sprout_social'
export PARTNER_DATASET_ID='sprout_social'
export SYNC_NAME=sprout_social
export PARTNER_PROJECT_ID=dev-partner-a-25693fa5

pipenv run dbt run --target cta --select tag:cta --full-refresh
```

2 - confirmed that the matview in dev-partner-a broke as a result:

```sql
SELECT * FROM `dev-partner-a-25693fa5.sprout_social.client_metadata`
```

3 - reran the partner dbt by clearing the [Airflow task in the dev Airflow DAG](https://f9ebbc83f6f3414381d6fa9a52957253-dot-us-central1.composer.googleusercontent.com/log?dag_id=sprout_social&task_id=sprout_social_0_partner_a.dbt_tasks.dbt_sprout_social.dbt_run_partner&execution_date=2024-01-27T22%3A25%3A00%2B00%3A00&map_index=-1)

4 - confirmed that the matview has been restored (same query as in 2)

All ran as intended 🎉 