### PR TITLE
fix: remove `TRUNCATE` pre-hook

### DIFF
--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -33,7 +33,6 @@ models:
       +incremental_strategy: insert_overwrite
       +on_schema_change: sync_all_columns
       +full_refresh: false
-      +pre-hook: "TRUNCATE TABLE {{ this }};"
     1_cta_incremental:
       +tags:
         - cta


### PR DESCRIPTION
This was a neat idea but it makes the dbt fail if the base table doesn't already exist, and there's no clean way to make it only run if the table already exists. RIP in spaghetti never forgetti