### PR TITLE
revert: replace past 6 date partitions in full_refresh models

### DIFF
--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/government_ids_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/government_ids_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/personal_emails_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/personal_emails_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/personal_faxes_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/personal_faxes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/personal_landlines_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/personal_landlines_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/personal_mobiles_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/personal_mobiles_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/social_insurance_programs_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/social_insurance_programs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_assignments_assigned_organizational_units_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_assignments_assigned_organizational_units_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_assignments_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_assignments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_assignments_home_organizational_units_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_assignments_home_organizational_units_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_emails_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_emails_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_faxes_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_faxes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_landlines_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_landlines_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_mobiles_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_mobiles_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_pagers_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/work_pagers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/adp_worker_management/models/1_cta_full_refresh/workers_base.sql
+++ b/dbt-cta/adp_worker_management/models/1_cta_full_refresh/workers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/activism_options_configs_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/activism_options_configs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/address_districts_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/address_districts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/admin_users_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/admin_users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/age_to_bin_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/age_to_bin_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/announcements_views_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/announcements_views_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/campaigns_people_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/campaigns_people_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/campaigns_teams_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/campaigns_teams_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/catalist_uploads_registration_forms_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/catalist_uploads_registration_forms_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/check_in_questions_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/check_in_questions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/collections_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/collections_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/collections_roles_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/collections_roles_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/contact_methods_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/contact_methods_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/coorganizations_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/coorganizations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/counties_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/counties_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/delayed_jobs_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/delayed_jobs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/deliveries_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/deliveries_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/delivery_forms_exclusions_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/delivery_forms_exclusions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/denominations_organizations_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/denominations_organizations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/denominations_people_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/denominations_people_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/documents_phone_banking_phone_banks_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/documents_phone_banking_phone_banks_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/email_templates_events_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/email_templates_events_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/events_teams_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/events_teams_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/field_management_goals_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/field_management_goals_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/field_management_projections_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/field_management_projections_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/friendly_id_slugs_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/friendly_id_slugs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/grouping_measurements_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/grouping_measurements_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/import_lcv_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/import_lcv_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/imports_error_rows_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/imports_error_rows_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/list_folders_users_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/list_folders_users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/lists_people_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/lists_people_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/locations_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/locations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/locations_organizations_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/locations_organizations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/organizations_teams_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/organizations_teams_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/projections_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/projections_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/public_event_links_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/public_event_links_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_comments_users_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_comments_users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_flag_triggers_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_flag_triggers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_flags_views_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_flags_views_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_flags_voter_registration_scans_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_flags_voter_registration_scans_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_phone_verification_question_translations_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_phone_verification_question_translations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_phone_verification_scripts_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/quality_control_phone_verification_scripts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/registrant_matches_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/registrant_matches_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/registration_forms_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/registration_forms_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/scans_qc_overview_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/scans_qc_overview_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/scheduled_exports_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/scheduled_exports_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/scheduled_exports_turfs_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/scheduled_exports_turfs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/schema_migrations_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/schema_migrations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/sent_emails_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/sent_emails_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/shifts_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/shifts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/state_party_codes_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/state_party_codes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/states_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/states_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/taggings_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/taggings_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/tags_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/tags_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/turf_levels_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/turf_levels_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/turfs_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/turfs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/user_profiles_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/user_profiles_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/versions_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/versions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/voted_labels_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/voted_labels_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/blocks/models/1_cta_full_refresh/vr_zips_lookup_base.sql
+++ b/dbt-cta/blocks/models/1_cta_full_refresh/vr_zips_lookup_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/facebook_marketing/models/1_cta_incremental/ads_insights_platform_and_device_base.sql
+++ b/dbt-cta/facebook_marketing/models/1_cta_incremental/ads_insights_platform_and_device_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/agent_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/agent_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/business_hour_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/business_hour_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/canned_response_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/canned_response_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/canned_response_folder_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/canned_response_folder_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/company_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/company_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/contact_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/contact_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/conversation_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/conversation_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/discussion_category_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/discussion_category_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/discussion_comment_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/discussion_comment_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/discussion_forum_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/discussion_forum_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/discussion_topic_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/discussion_topic_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/email_config_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/email_config_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/email_mailbox_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/email_mailbox_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/group_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/group_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/product_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/product_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/role_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/role_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/satisfaction_rating_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/satisfaction_rating_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/scenario_automation_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/scenario_automation_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/settings_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/settings_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/sla_policy_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/sla_policy_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/solution_article_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/solution_article_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/solution_category_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/solution_category_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/solution_folder_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/solution_folder_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/survey_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/survey_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/survey_question_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/survey_question_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/ticket_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/ticket_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/ticket_field_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/ticket_field_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/freshdesk/models/1_cta_full_refresh/time_entries_base.sql
+++ b/dbt-cta/freshdesk/models/1_cta_full_refresh/time_entries_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/google_directory/models/1_cta_full_refresh/group_members.sql
+++ b/dbt-cta/google_directory/models/1_cta_full_refresh/group_members.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/google_directory/models/1_cta_full_refresh/groups.sql
+++ b/dbt-cta/google_directory/models/1_cta_full_refresh/groups.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/google_directory/models/1_cta_full_refresh/users.sql
+++ b/dbt-cta/google_directory/models/1_cta_full_refresh/users.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/google_directory/models/1_cta_full_refresh/users_emails.sql
+++ b/dbt-cta/google_directory/models/1_cta_full_refresh/users_emails.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/google_directory/models/1_cta_full_refresh/users_externalIds.sql
+++ b/dbt-cta/google_directory/models/1_cta_full_refresh/users_externalIds.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/google_directory/models/1_cta_full_refresh/users_name.sql
+++ b/dbt-cta/google_directory/models/1_cta_full_refresh/users_name.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/google_directory/models/1_cta_full_refresh/users_phones.sql
+++ b/dbt-cta/google_directory/models/1_cta_full_refresh/users_phones.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/google_directory/models/1_cta_full_refresh/users_relations.sql
+++ b/dbt-cta/google_directory/models/1_cta_full_refresh/users_relations.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/mailchimp/models/1_cta_full_refresh/campaigns_base.sql
+++ b/dbt-cta/mailchimp/models/1_cta_full_refresh/campaigns_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/affiliations_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/affiliations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/event_co_hosts_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/event_co_hosts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/event_tags_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/event_tags_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/events_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/events_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/organizations_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/organizations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/participations_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/participations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/sms_opt_ins_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/sms_opt_ins_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/timeslots_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/timeslots_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/users_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/van_events_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/van_events_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/van_locations_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/van_locations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/van_persons_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/van_persons_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/van_shifts_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/van_shifts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/mobilize/models/1_cta_full_refresh/van_signups_base.sql
+++ b/dbt-cta/mobilize/models/1_cta_full_refresh/van_signups_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/spoke_mo/models/1_cta_full_refresh/zip_code_base.sql
+++ b/dbt-cta/spoke_mo/models/1_cta_full_refresh/zip_code_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions = partitions_to_replace,

--- a/dbt-cta/square/models/1_cta_full_refresh/customers_address_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/customers_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/customers_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/customers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/customers_cards_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/customers_cards_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/customers_cards_billing_address_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/customers_cards_billing_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/customers_preferences_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/customers_preferences_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/locations_address_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/locations_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/locations_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/locations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_discounts_applied_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_discounts_applied_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_discounts_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_discounts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_pickup_details_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_pickup_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_pickup_details_recipient_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_pickup_details_recipient_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_shipment_details_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_shipment_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_shipment_details_recipient_address_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_shipment_details_recipient_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_shipment_details_recipient_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_fulfillments_shipment_details_recipient_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_applied_discounts_applied_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_applied_discounts_applied_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_applied_discounts_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_applied_discounts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_applied_taxes_applied_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_applied_taxes_applied_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_applied_taxes_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_applied_taxes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_base_price_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_base_price_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_gross_sales_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_gross_sales_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_modifiers_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_modifiers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_modifiers_base_price_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_modifiers_base_price_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_modifiers_total_price_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_modifiers_total_price_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_total_discount_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_total_discount_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_total_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_total_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_total_tax_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_total_tax_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_variation_total_price_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_line_items_variation_total_price_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_discount_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_discount_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_service_charge_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_service_charge_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_tax_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_tax_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_tip_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_tip_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_total_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_net_amounts_total_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_refunds_amount_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_refunds_amount_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_refunds_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_refunds_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_discount_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_discount_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_service_charge_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_service_charge_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_tax_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_tax_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_tip_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_tip_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_total_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_return_amounts_total_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_returns_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_returns_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_base_price_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_base_price_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_gross_return_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_gross_return_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_total_discount_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_total_discount_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_total_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_total_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_total_tax_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_total_tax_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_variation_total_price_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_returns_return_line_items_variation_total_price_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_service_charges_amount_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_service_charges_amount_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_service_charges_applied_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_service_charges_applied_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_service_charges_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_service_charges_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_service_charges_total_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_service_charges_total_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_service_charges_total_tax_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_service_charges_total_tax_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_source_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_source_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_taxes_applied_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_taxes_applied_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_taxes_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_taxes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_amount_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_amount_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_card_details_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_card_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_card_details_card_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_card_details_card_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_cash_details_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_cash_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_cash_details_buyer_tendered_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_cash_details_buyer_tendered_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_cash_details_change_back_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_tenders_cash_details_change_back_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_total_discount_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_total_discount_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_total_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_total_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_total_service_charge_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_total_service_charge_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_total_tax_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_total_tax_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/orders_total_tip_money_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/orders_total_tip_money_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/shifts_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/shifts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/shifts_breaks_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/shifts_breaks_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/shifts_wage_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/shifts_wage_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/shifts_wage_hourly_rate_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/shifts_wage_hourly_rate_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/team_member_wages_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/team_member_wages_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/team_member_wages_hourly_rate_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/team_member_wages_hourly_rate_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/team_members_assigned_locations_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/team_members_assigned_locations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/square/models/1_cta_full_refresh/team_members_base.sql
+++ b/dbt-cta/square/models/1_cta_full_refresh/team_members_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/advertisers_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/advertisers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/campaigns_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/campaigns_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/campaigns_day_part_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/campaigns_day_part_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/conversion_trackers_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/conversion_trackers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/line_items_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/line_items_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_creatives_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_creatives_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_icon_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_icon_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_input_data_audio_creatives_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_input_data_audio_creatives_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_input_data_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_input_data_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_input_data_display_js_creative_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_input_data_display_js_creative_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_input_data_video_creatives_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_input_data_video_creatives_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_vast_trackers_base.sql
+++ b/dbt-cta/stackadapt/models/1_cta_full_refresh/native_ads_vast_trackers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     cluster_by = "_airbyte_emitted_at",

--- a/dbt-cta/stripe/models/1_cta_full_refresh/balance_transactions_fee_details_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/balance_transactions_fee_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/bank_accounts_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/bank_accounts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_card_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_card_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_fraud_details_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_fraud_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_outcome_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_outcome_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_ach_credit_transfer_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_ach_credit_transfer_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_ach_debit_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_ach_debit_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_bancontact_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_bancontact_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_card_present_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_card_present_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_card_present_receipt_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_card_present_receipt_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_checks_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_checks_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_eps_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_eps_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_giropay_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_giropay_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_ideal_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_ideal_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_installments_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_installments_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_installments_plan_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_installments_plan_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_multibanco_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_multibanco_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_p24_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_p24_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_sepa_debit_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_sepa_debit_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_sofort_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_sofort_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_three_d_secure_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_three_d_secure_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_masterpass_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_masterpass_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_masterpass_billing_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_masterpass_billing_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_masterpass_shipping_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_masterpass_shipping_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_visa_checkout_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_visa_checkout_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_visa_checkout_billing_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_visa_checkout_billing_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_visa_checkout_shipping_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_payment_method_details_card_wallet_visa_checkout_shipping_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_refunds_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_refunds_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_ach_credit_transfer_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_ach_credit_transfer_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_card_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_card_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_owner_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_owner_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_owner_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_owner_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_receiver_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_receiver_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_redirect_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/charges_source_redirect_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_after_expiration_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_after_expiration_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_after_expiration_recovery_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_after_expiration_recovery_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_automatic_tax_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_automatic_tax_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_consent_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_consent_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_consent_collection_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_consent_collection_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_customer_details_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_customer_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_customer_details_tax_ids_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_customer_details_tax_ids_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_discounts_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_discounts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_discounts_discount_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_discounts_discount_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_discounts_discount_coupon_applies_to_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_discounts_discount_coupon_applies_to_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_discounts_discount_coupon_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_discounts_discount_coupon_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_price_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_price_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_price_recurring_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_price_recurring_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_price_tiers_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_price_tiers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_price_transform_quantity_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_price_transform_quantity_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_taxes_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_taxes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_taxes_rate_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_line_items_taxes_rate_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_payment_method_options_acss_debit_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_payment_method_options_acss_debit_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_payment_method_options_acss_debit_mandate_options_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_payment_method_options_acss_debit_mandate_options_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_payment_method_options_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_payment_method_options_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_payment_method_options_boleto_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_payment_method_options_boleto_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_payment_method_options_oxxo_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_payment_method_options_oxxo_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_phone_number_collection_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_phone_number_collection_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_shipping_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_shipping_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_shipping_address_collection_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_shipping_address_collection_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_shipping_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_shipping_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_tax_id_collection_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_tax_id_collection_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_total_details_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_total_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_total_details_breakdown_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_total_details_breakdown_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_total_details_breakdown_discounts_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_total_details_breakdown_discounts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_total_details_breakdown_taxes_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_total_details_breakdown_taxes_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_total_details_breakdown_taxes_rate_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/checkout_sessions_total_details_breakdown_taxes_rate_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/customer_balance_transactions_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/customer_balance_transactions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/customers_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/customers_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/customers_cards_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/customers_cards_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/customers_discount_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/customers_discount_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/customers_discount_coupon_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/customers_discount_coupon_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/customers_invoice_settings_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/customers_invoice_settings_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/customers_shipping_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/customers_shipping_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/customers_shipping_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/customers_shipping_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/customers_subscriptions_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/customers_subscriptions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/disputes_balance_transactions_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/disputes_balance_transactions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/disputes_evidence_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/disputes_evidence_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/disputes_evidence_details_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/disputes_evidence_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/external_account_bank_accounts_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/external_account_bank_accounts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/external_account_cards_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/external_account_cards_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/invoice_items_period_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/invoice_items_period_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/invoice_items_plan_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/invoice_items_plan_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/invoice_items_plan_tiers_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/invoice_items_plan_tiers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/invoice_line_items_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/invoice_line_items_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/invoice_line_items_period_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/invoice_line_items_period_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/invoice_line_items_plan_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/invoice_line_items_plan_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/invoice_line_items_plan_tiers_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/invoice_line_items_plan_tiers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_charges_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_charges_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_acss_debit_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_acss_debit_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_au_becs_debit_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_au_becs_debit_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_bacs_debit_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_bacs_debit_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_billing_details_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_billing_details_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_billing_details_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_billing_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_boleto_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_boleto_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_checks_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_checks_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_generated_from_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_generated_from_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_generated_from_payment_method_details_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_generated_from_payment_method_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_generated_from_payment_method_details_card_present_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_generated_from_payment_method_details_card_present_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_generated_from_payment_method_details_card_present_receipt_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_generated_from_payment_method_details_card_present_receipt_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_networks_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_networks_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_three_d_secure_usage_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_three_d_secure_usage_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_masterpass_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_masterpass_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_masterpass_billing_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_masterpass_billing_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_masterpass_shipping_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_masterpass_shipping_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_visa_checkout_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_visa_checkout_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_visa_checkout_billing_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_visa_checkout_billing_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_visa_checkout_shipping_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_card_wallet_visa_checkout_shipping_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_eps_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_eps_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_fpx_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_fpx_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_ideal_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_ideal_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_p24_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_p24_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_sepa_debit_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_sepa_debit_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_sepa_debit_generated_from_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_sepa_debit_generated_from_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_sofort_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_last_payment_error_payment_method_sofort_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_alipay_handle_redirect_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_alipay_handle_redirect_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_boleto_display_details_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_boleto_display_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_oxxo_display_details_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_oxxo_display_details_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_redirect_to_url_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_redirect_to_url_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_verify_with_microdeposits_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_verify_with_microdeposits_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_wechat_pay_display_qr_code_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_wechat_pay_display_qr_code_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_wechat_pay_redirect_to_android_app_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_wechat_pay_redirect_to_android_app_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_wechat_pay_redirect_to_ios_app_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_next_action_wechat_pay_redirect_to_ios_app_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_shipping_address_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_shipping_address_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_shipping_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_shipping_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_transfer_data_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payment_intents_transfer_data_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/payouts_bank_account_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/payouts_bank_account_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/plans_tiers_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/plans_tiers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/products_package_dimensions_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/products_package_dimensions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/promotion_codes_coupon_applies_to_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/promotion_codes_coupon_applies_to_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/promotion_codes_coupon_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/promotion_codes_coupon_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/promotion_codes_restrictions_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/promotion_codes_restrictions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/subscription_items_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/subscription_items_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/subscription_items_plan_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/subscription_items_plan_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/subscription_items_plan_tiers_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/subscription_items_plan_tiers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/subscriptions_discount_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/subscriptions_discount_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/subscriptions_discount_coupon_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/subscriptions_discount_coupon_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/subscriptions_items_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/subscriptions_items_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/subscriptions_plan_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/subscriptions_plan_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/subscriptions_plan_tiers_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/subscriptions_plan_tiers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/stripe/models/1_cta_full_refresh/transfers_reversals_base.sql
+++ b/dbt-cta/stripe/models/1_cta_full_refresh/transfers_reversals_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 
 {{ config(

--- a/dbt-cta/twilio/models/1_cta_full_refresh/accounts_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/accounts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/addresses_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/addresses_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/applications_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/applications_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/available_phone_number_countries_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/available_phone_number_countries_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/available_phone_numbers_local_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/available_phone_numbers_local_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/available_phone_numbers_mobile_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/available_phone_numbers_mobile_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/available_phone_numbers_toll_free_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/available_phone_numbers_toll_free_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/conference_participants_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/conference_participants_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/dependent_phone_numbers_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/dependent_phone_numbers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/incoming_phone_numbers_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/incoming_phone_numbers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/keys_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/keys_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/outgoing_caller_ids_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/outgoing_caller_ids_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/queues_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/queues_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/transcriptions_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/transcriptions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/usage_records_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/usage_records_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/twilio/models/1_cta_full_refresh/usage_triggers_base.sql
+++ b/dbt-cta/twilio/models/1_cta_full_refresh/usage_triggers_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_contacts_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_addresses_contacts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_officials_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/offices_officials_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/officials_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/officials_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/regions_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/regions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,

--- a/dbt-cta/usvote_foundation/models/1_cta_full_refresh/states_base.sql
+++ b/dbt-cta/usvote_foundation/models/1_cta_full_refresh/states_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     'timestamp_trunc(current_timestamp, day)',
-    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)'
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
+    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
 ] %}
 {{ config(
     partitions=partitions_to_replace,


### PR DESCRIPTION
A lot of syncs have been failing in dev because of dev Airbyte being down for one morning. Let's bring this change back (which I think we abandoned when we added the TRUNCATE pre-hook?) to make our dbt a bit more resilient to temporary Airbyte outages.

The file diffs look intense - it's just a find-and-replace across all of our full refresh models, replacing this line:

```
    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
```

with this:

```
    'timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)',
    'timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)',
    'timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)',
    'timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)',
    'timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)',
    'timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)'
```