### PR TITLE
hotfix: replace p6d of date partitions for blocks_incremental

### DIFF
--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/address_districts_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/address_districts_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/age_to_bin_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/age_to_bin_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/announcements_views_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/announcements_views_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/ar_internal_metadata_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/ar_internal_metadata_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/campaigns_people_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/campaigns_people_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/campaigns_teams_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/campaigns_teams_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/catalist_uploads_registration_forms_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/catalist_uploads_registration_forms_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/collections_roles_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/collections_roles_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/coorganizations_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/coorganizations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/delivery_forms_exclusions_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/delivery_forms_exclusions_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/denominations_organizations_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/denominations_organizations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/denominations_people_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/denominations_people_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/email_templates_events_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/email_templates_events_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/events_teams_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/events_teams_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/list_folders_users_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/list_folders_users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/lists_people_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/lists_people_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/locations_organizations_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/locations_organizations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/missing_fks_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/missing_fks_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/organizations_teams_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/organizations_teams_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/projections_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/projections_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/quality_control_comments_users_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/quality_control_comments_users_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/quality_control_flags_views_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/quality_control_flags_views_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/quality_control_flags_voter_registration_scans_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/quality_control_flags_voter_registration_scans_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/scans_qc_overview_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/scans_qc_overview_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/scheduled_exports_turfs_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/scheduled_exports_turfs_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/schema_migrations_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/schema_migrations_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/states_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/states_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",

--- a/dbt-cta/blocks_incremental/models/1_cta_full_refresh/voted_labels_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_full_refresh/voted_labels_base.sql
@@ -1,6 +1,11 @@
 {% set partitions_to_replace = [
     "timestamp_trunc(current_timestamp, day)",
-    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)"
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 1 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 2 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 3 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 4 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 5 day), day)",
+    "timestamp_trunc(timestamp_sub(current_timestamp, interval 6 day), day)"
 ] %}
 {{ config(
     cluster_by = "_airbyte_extracted_at",


### PR DESCRIPTION
same change as for all the other full_refresh models in https://github.com/community-tech-alliance/dbt-cta/pull/325 - blocks_incremental got missed/reverted by accident