### PR TITLE
hotfix: add deduping CTEs to FB Pages sync

### DIFF
--- a/dbt-cta/facebook_pages/models/0_ctes/page_ab2.sql
+++ b/dbt-cta/facebook_pages/models/0_ctes/page_ab2.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by _airbyte_page_hashid order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('page_ab1') }}
+    )
+where rownum = 1

--- a/dbt-cta/facebook_pages/models/0_ctes/page_insights_ab2.sql
+++ b/dbt-cta/facebook_pages/models/0_ctes/page_insights_ab2.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by _airbyte_page_insights_hashid order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('page_insights_ab1') }}
+    )
+where rownum = 1

--- a/dbt-cta/facebook_pages/models/0_ctes/post_ab2.sql
+++ b/dbt-cta/facebook_pages/models/0_ctes/post_ab2.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by _airbyte_post_hashid order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('post_ab1') }}
+    )
+where rownum = 1

--- a/dbt-cta/facebook_pages/models/0_ctes/post_insights_ab2.sql
+++ b/dbt-cta/facebook_pages/models/0_ctes/post_insights_ab2.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by _airbyte_post_insights_hashid order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('post_insights_ab1') }}
+    )
+where rownum = 1

--- a/dbt-cta/facebook_pages/models/1_cta_full_refresh/page_base.sql
+++ b/dbt-cta/facebook_pages/models/1_cta_full_refresh/page_base.sql
@@ -15,7 +15,7 @@
 ) }}
 
 -- Final base SQL model
--- depends_on: {{ ref('page_ab1') }}
+-- depends_on: {{ ref('page_ab2') }}
 select
     `_airbyte_page_hashid`,
     `_airbyte_extracted_at`,
@@ -227,7 +227,7 @@ select
     `category`,
     `unread_notif_count`,
     `leadgen_tos_accepted`
-from {{ ref('page_ab1') }}
+from {{ ref('page_ab2') }}
 
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})

--- a/dbt-cta/facebook_pages/models/1_cta_full_refresh/page_insights_base.sql
+++ b/dbt-cta/facebook_pages/models/1_cta_full_refresh/page_insights_base.sql
@@ -15,7 +15,7 @@
 ) }}
 
 -- Final base SQL model
--- depends_on: {{ ref('page_insights_ab1') }}
+-- depends_on: {{ ref('page_insights_ab2') }}
 select
     `_airbyte_extracted_at`,
     `_airbyte_page_insights_hashid`,
@@ -26,7 +26,7 @@ select
     `description`,
     `id`,
     `title`
-from {{ ref('page_insights_ab1') }}
+from {{ ref('page_insights_ab2') }}
 
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})

--- a/dbt-cta/facebook_pages/models/1_cta_full_refresh/post_base.sql
+++ b/dbt-cta/facebook_pages/models/1_cta_full_refresh/post_base.sql
@@ -15,7 +15,7 @@
 ) }}
 
 -- Final base SQL model
--- depends_on: {{ ref('post_ab1') }}
+-- depends_on: {{ ref('post_ab2') }}
 select
     `_airbyte_post_hashid`,
     `_airbyte_extracted_at`,
@@ -32,7 +32,7 @@ select
     `message`,
     `permalink_url`,
     `actions`
-from {{ ref('post_ab1') }}
+from {{ ref('post_ab2') }}
 
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})

--- a/dbt-cta/facebook_pages/models/1_cta_full_refresh/post_insights_base.sql
+++ b/dbt-cta/facebook_pages/models/1_cta_full_refresh/post_insights_base.sql
@@ -15,7 +15,7 @@
 ) }}
 
 -- Final base SQL model
--- depends_on: {{ ref('post_insights_ab1') }}
+-- depends_on: {{ ref('post_insights_ab2') }}
 select
     `_airbyte_extracted_at`,
     `_airbyte_post_insights_hashid`,
@@ -26,7 +26,7 @@ select
     `description`,
     `id`,
     `title`
-from {{ ref('post_insights_ab1') }}
+from {{ ref('post_insights_ab2') }}
 
 {% if is_incremental() %}
 where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})


### PR DESCRIPTION
We've done this for most/all other syncs, not sure if this was missed or reverted somehow but anyway it works locally and we need these to get tests to pass for re-enabled syncs so I'm gonna YOLO it in!