### PR TITLE
hotfix (blocks): registration_type in scans_qc_overview is now a string

### DIFF
--- a/dbt-cta/blocks/models/0_ctes/scans_qc_overview_ab2.sql
+++ b/dbt-cta/blocks/models/0_ctes/scans_qc_overview_ab2.sql
@@ -50,7 +50,7 @@ select
     cast(phone_verification_completed_by_user_id as {{ dbt_utils.type_bigint() }}) as phone_verification_completed_by_user_id,
     cast(voting_zipcode as {{ dbt_utils.type_string() }}) as voting_zipcode,
     cast(mailing_zipcode as {{ dbt_utils.type_string() }}) as mailing_zipcode,
-    cast(registration_type as {{ dbt_utils.type_bigint() }}) as registration_type,
+    cast(registration_type as {{ dbt_utils.type_string() }}) as registration_type,
     cast(registration_form_id as {{ dbt_utils.type_bigint() }}) as registration_form_id,
     cast(packet_filename as {{ dbt_utils.type_string() }}) as packet_filename,
     cast(name_prefix as {{ dbt_utils.type_string() }}) as name_prefix,


### PR DESCRIPTION
@emily-flambe fixed this field on another table a few weeks ago in [this PR](https://github.com/community-tech-alliance/dbt-cta/pull/338), but the same change is needed on the `scans_qc_overview` table now too. 