### PR TITLE
hotfix: remove fields that are no longer coming in for openfield

### DIFF
--- a/dbt-cta/openfield/models/0_ctes/redshift_people_name_conversations_cte1.sql
+++ b/dbt-cta/openfield/models/0_ctes/redshift_people_name_conversations_cte1.sql
@@ -39,8 +39,6 @@ select
     cast(question_id as {{ dbt_utils.type_bigint() }}) as question_id,
     cast(question_text as {{ dbt_utils.type_string() }}) as question_text,
     cast(response as {{ dbt_utils.type_string() }}) as response,
-    cast(partition_schema_name as {{ dbt_utils.type_string() }}) as partition_schema_name,
-    cast(partition_name as {{ dbt_utils.type_string() }}) as partition_name,
 
     -- new fields
     {{ dbt_utils.surrogate_key([
@@ -75,8 +73,6 @@ select
         'question_id',
         'question_text',
         'response',
-        'partition_schema_name',
-        'partition_name',
     ]) }} as _redshift_people_name_conversations_hashid,
     {{ current_timestamp() }} as _cta_loaded_at
 from {{ source('cta', '_raw_redshift_people_name_conversations') }}

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_name_conversations_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_name_conversations_base.sql
@@ -47,8 +47,6 @@ select
     question_id,
     question_text,
     response,
-    partition_schema_name,
-    partition_name,
     _redshift_people_name_conversations_hashid,
     _cta_loaded_at
 from {{ ref('redshift_people_name_conversations_cte2') }}


### PR DESCRIPTION
OpenField made some schema changes, this table must have been missed in the last PR because no org was receiving data for it until today. Updating to remove fields that are no longer being sent over by openfield