### PR TITLE
thrutext: on_schema_change should be `sync_all_columns`

### DIFF
--- a/dbt-cta/thrutext/models/1_cta_incremental/daily_messages_base.sql
+++ b/dbt-cta/thrutext/models/1_cta_incremental/daily_messages_base.sql
@@ -7,7 +7,7 @@
             "granularity": "day",
         },
         unique_key="_daily_messages_hashid",
-        on_schema_change="add"
+        on_schema_change="sync_all_columns"
     )
 }}
 

--- a/dbt-cta/thrutext/models/1_cta_incremental/daily_surveys_base.sql
+++ b/dbt-cta/thrutext/models/1_cta_incremental/daily_surveys_base.sql
@@ -7,7 +7,7 @@
             "granularity": "day",
         },
         unique_key="_daily_surveys_hashid",
-        on_schema_change="add"
+        on_schema_change="sync_all_columns"
     )
 }}
 

--- a/dbt-cta/thrutext/models/1_cta_incremental/opt_outs_base.sql
+++ b/dbt-cta/thrutext/models/1_cta_incremental/opt_outs_base.sql
@@ -7,7 +7,7 @@
             "granularity": "day",
         },
         unique_key="_opt_outs_hashid",
-        on_schema_change="add"
+        on_schema_change="sync_all_columns"
     )
 }}
 


### PR DESCRIPTION
This enables the dbt to run if columns are removed. Having this set to `add` only allows new columns to be added, but sometimes columns disappear in a Thrutext export.