### PR TITLE
remove incremental where clause for Action Network

### DIFF
--- a/dbt-cta/action_network/models/1_cta_full_refresh/action_keywords_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/action_keywords_base.sql
@@ -28,7 +28,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_action_keywords_hashid
 from {{ ref('action_keywords_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/action_questions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/action_questions_base.sql
@@ -29,7 +29,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_action_questions_hashid
 from {{ ref('action_questions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/actions_base.sql
@@ -27,7 +27,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_actions_hashid
 from {{ ref('actions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/answers_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/answers_base.sql
@@ -42,7 +42,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_answers_hashid
 from {{ ref('answers_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/call_campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/call_campaigns_base.sql
@@ -77,7 +77,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_call_campaigns_hashid
 from {{ ref('call_campaigns_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/call_targets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/call_targets_base.sql
@@ -37,7 +37,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_call_targets_hashid
 from {{ ref('call_targets_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/calls_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/calls_base.sql
@@ -42,7 +42,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_calls_hashid
 from {{ ref('calls_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/campaigns_base.sql
@@ -40,7 +40,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_campaigns_hashid
 from {{ ref('campaigns_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/catalist_syncs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/catalist_syncs_base.sql
@@ -34,7 +34,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_catalist_syncs_hashid
 from {{ ref('catalist_syncs_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/child_permissions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/child_permissions_base.sql
@@ -28,7 +28,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_child_permissions_hashid
 from {{ ref('child_permissions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/collections_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/collections_base.sql
@@ -27,7 +27,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_collections_hashid
 from {{ ref('collections_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/collections_groups_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/collections_groups_base.sql
@@ -26,7 +26,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_collections_groups_hashid
 from {{ ref('collections_groups_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/comments_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/comments_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_comments_hashid
 from {{ ref('comments_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_field_syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_field_syndications_base.sql
@@ -27,7 +27,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_core_field_syndications_hashid
 from {{ ref('core_field_syndications_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_field_timezones_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_field_timezones_base.sql
@@ -26,7 +26,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_core_field_timezones_hashid
 from {{ ref('core_field_timezones_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_base.sql
@@ -38,7 +38,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_core_fields_hashid
 from {{ ref('core_fields_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_counties_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_counties_base.sql
@@ -24,7 +24,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_core_fields_counties_hashid
 from {{ ref('core_fields_counties_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_ocdids_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/core_fields_ocdids_base.sql
@@ -24,7 +24,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_core_fields_ocdids_hashid
 from {{ ref('core_fields_ocdids_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/counties_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/counties_base.sql
@@ -25,7 +25,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_counties_hashid
 from {{ ref('counties_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/deliveries_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/deliveries_base.sql
@@ -45,7 +45,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_deliveries_hashid
 from {{ ref('deliveries_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/delivery_targets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/delivery_targets_base.sql
@@ -42,7 +42,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_delivery_targets_hashid
 from {{ ref('delivery_targets_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donation_payments_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donation_payments_base.sql
@@ -40,7 +40,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_donation_payments_hashid
 from {{ ref('donation_payments_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donation_recipients_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donation_recipients_base.sql
@@ -27,7 +27,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_donation_recipients_hashid
 from {{ ref('donation_recipients_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donations_base.sql
@@ -49,7 +49,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_donations_hashid
 from {{ ref('donations_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/donations_recurring_donations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/donations_recurring_donations_base.sql
@@ -26,7 +26,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_donations_recurring_donations_hashid
 from {{ ref('donations_recurring_donations_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_10_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_10_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_10_hashid
 from {{ ref('email_activities_10_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_11_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_11_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_11_hashid
 from {{ ref('email_activities_11_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_12_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_12_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_12_hashid
 from {{ ref('email_activities_12_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_13_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_13_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_13_hashid
 from {{ ref('email_activities_13_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_14_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_14_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_14_hashid
 from {{ ref('email_activities_14_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_15_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_15_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_15_hashid
 from {{ ref('email_activities_15_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_16_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_16_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_16_hashid
 from {{ ref('email_activities_16_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_1_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_1_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_1_hashid
 from {{ ref('email_activities_1_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_2_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_2_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_2_hashid
 from {{ ref('email_activities_2_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_3_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_3_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_3_hashid
 from {{ ref('email_activities_3_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_4_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_4_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_4_hashid
 from {{ ref('email_activities_4_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_5_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_5_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_5_hashid
 from {{ ref('email_activities_5_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_6_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_6_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_6_hashid
 from {{ ref('email_activities_6_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_7_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_7_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_7_hashid
 from {{ ref('email_activities_7_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_8_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_8_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_8_hashid
 from {{ ref('email_activities_8_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_9_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_9_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_9_hashid
 from {{ ref('email_activities_9_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_activities_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_activities_hashid
 from {{ ref('email_activities_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_campaign_members_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_campaign_members_base.sql
@@ -26,7 +26,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_campaign_members_hashid
 from {{ ref('email_campaign_members_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_campaigns_base.sql
@@ -27,7 +27,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_campaigns_hashid
 from {{ ref('email_campaigns_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_fields_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_fields_base.sql
@@ -30,7 +30,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_fields_hashid
 from {{ ref('email_fields_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_stats_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_stats_base.sql
@@ -29,7 +29,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_stats_hashid
 from {{ ref('email_stats_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_templates_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_templates_base.sql
@@ -38,7 +38,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_templates_hashid
 from {{ ref('email_templates_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/email_tests_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/email_tests_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_email_tests_hashid
 from {{ ref('email_tests_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/emails_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/emails_base.sql
@@ -56,7 +56,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_emails_hashid
 from {{ ref('emails_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_invites_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_invites_base.sql
@@ -27,7 +27,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_event_campaign_invites_hashid
 from {{ ref('event_campaign_invites_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_uploads_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/event_campaign_uploads_base.sql
@@ -33,7 +33,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_event_campaign_uploads_hashid
 from {{ ref('event_campaign_uploads_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/event_campaigns_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/event_campaigns_base.sql
@@ -93,7 +93,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_event_campaigns_hashid
 from {{ ref('event_campaigns_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/events_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/events_base.sql
@@ -102,7 +102,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_events_hashid
 from {{ ref('events_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/field_names_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/field_names_base.sql
@@ -33,7 +33,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_field_names_hashid
 from {{ ref('field_names_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/field_names_groups_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/field_names_groups_base.sql
@@ -25,7 +25,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_field_names_groups_hashid
 from {{ ref('field_names_groups_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/field_values_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/field_values_base.sql
@@ -28,7 +28,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_field_values_hashid
 from {{ ref('field_values_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/filter_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/filter_actions_base.sql
@@ -29,7 +29,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_filter_actions_hashid
 from {{ ref('filter_actions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/filters_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/filters_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_filters_hashid
 from {{ ref('filters_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/forms_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/forms_base.sql
@@ -75,7 +75,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_forms_hashid
 from {{ ref('forms_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/fundraisings_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/fundraisings_base.sql
@@ -75,7 +75,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_fundraisings_hashid
 from {{ ref('fundraisings_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_actions_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_group_growth_by_source_actions_hashid
 from {{ ref('group_growth_by_source_actions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_codes_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/group_growth_by_source_codes_base.sql
@@ -31,7 +31,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_group_growth_by_source_codes_hashid
 from {{ ref('group_growth_by_source_codes_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/group_invites_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/group_invites_base.sql
@@ -29,7 +29,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_group_invites_hashid
 from {{ ref('group_invites_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/groups_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/groups_base.sql
@@ -109,7 +109,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_groups_hashid
 from {{ ref('groups_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/groups_syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/groups_syndications_base.sql
@@ -31,7 +31,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_groups_syndications_hashid
 from {{ ref('groups_syndications_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/groups_users_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/groups_users_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_groups_users_hashid
 from {{ ref('groups_users_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ladders_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ladders_base.sql
@@ -34,7 +34,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_ladders_hashid
 from {{ ref('ladders_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/letter_templates_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/letter_templates_base.sql
@@ -33,7 +33,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_letter_templates_hashid
 from {{ ref('letter_templates_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/letters_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/letters_base.sql
@@ -72,7 +72,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_letters_hashid
 from {{ ref('letters_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/lists_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/lists_base.sql
@@ -57,7 +57,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_lists_hashid
 from {{ ref('lists_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/locations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/locations_base.sql
@@ -36,7 +36,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_locations_hashid
 from {{ ref('locations_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/message_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/message_actions_base.sql
@@ -29,7 +29,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_message_actions_hashid
 from {{ ref('message_actions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_fields_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_fields_base.sql
@@ -28,7 +28,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_mobile_message_fields_hashid
 from {{ ref('mobile_message_fields_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_stats_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/mobile_message_stats_base.sql
@@ -29,7 +29,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_mobile_message_stats_hashid
 from {{ ref('mobile_message_stats_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/mobile_messages_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/mobile_messages_base.sql
@@ -43,7 +43,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_mobile_messages_hashid
 from {{ ref('mobile_messages_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/networks_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/networks_base.sql
@@ -35,7 +35,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_networks_hashid
 from {{ ref('networks_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/networks_users_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/networks_users_base.sql
@@ -27,7 +27,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_networks_users_hashid
 from {{ ref('networks_users_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/notification_settings_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/notification_settings_base.sql
@@ -28,7 +28,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_notification_settings_hashid
 from {{ ref('notification_settings_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ocdids_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ocdids_base.sql
@@ -26,7 +26,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_ocdids_hashid
 from {{ ref('ocdids_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/page_actions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/page_actions_base.sql
@@ -27,7 +27,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_page_actions_hashid
 from {{ ref('page_actions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/page_wrappers_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/page_wrappers_base.sql
@@ -35,7 +35,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_page_wrappers_hashid
 from {{ ref('page_wrappers_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/petitions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/petitions_base.sql
@@ -78,7 +78,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_petitions_hashid
 from {{ ref('petitions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/phone_change_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/phone_change_logs_base.sql
@@ -31,7 +31,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_phone_change_logs_hashid
 from {{ ref('phone_change_logs_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/phone_dedupe_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/phone_dedupe_logs_base.sql
@@ -31,7 +31,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_phone_dedupe_logs_hashid
 from {{ ref('phone_dedupe_logs_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/queries_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/queries_base.sql
@@ -30,7 +30,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_queries_hashid
 from {{ ref('queries_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/questions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/questions_base.sql
@@ -37,7 +37,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_questions_hashid
 from {{ ref('questions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/recurring_donations_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/recurring_donations_base.sql
@@ -31,7 +31,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_recurring_donations_hashid
 from {{ ref('recurring_donations_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/reports_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/reports_base.sql
@@ -41,7 +41,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_reports_hashid
 from {{ ref('reports_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/rsvps_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/rsvps_base.sql
@@ -43,7 +43,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_rsvps_hashid
 from {{ ref('rsvps_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/share_options_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/share_options_base.sql
@@ -50,7 +50,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_share_options_hashid
 from {{ ref('share_options_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/signatures_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/signatures_base.sql
@@ -42,7 +42,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_signatures_hashid
 from {{ ref('signatures_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_message_activities_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_message_activities_base.sql
@@ -35,7 +35,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_sms_message_activities_hashid
 from {{ ref('sms_message_activities_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_messages_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_messages_base.sql
@@ -33,7 +33,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_sms_messages_hashid
 from {{ ref('sms_messages_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_status_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_status_logs_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_sms_status_logs_hashid
 from {{ ref('sms_status_logs_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_statuses_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_statuses_base.sql
@@ -31,7 +31,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_sms_statuses_hashid
 from {{ ref('sms_statuses_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/sms_unsubscriptions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/sms_unsubscriptions_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_sms_unsubscriptions_hashid
 from {{ ref('sms_unsubscriptions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/source_codes_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/source_codes_base.sql
@@ -27,7 +27,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_source_codes_hashid
 from {{ ref('source_codes_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/steps_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/steps_base.sql
@@ -30,7 +30,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_steps_hashid
 from {{ ref('steps_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/subscription_statuses_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/subscription_statuses_base.sql
@@ -31,7 +31,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_subscription_statuses_hashid
 from {{ ref('subscription_statuses_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_1_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_1_base.sql
@@ -40,7 +40,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_subscriptions_1_hashid
 from {{ ref('subscriptions_1_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/subscriptions_base.sql
@@ -40,7 +40,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_subscriptions_hashid
 from {{ ref('subscriptions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/syndications_base.sql
@@ -44,7 +44,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_syndications_hashid
 from {{ ref('syndications_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/tag_syndications_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/tag_syndications_base.sql
@@ -29,7 +29,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_tag_syndications_hashid
 from {{ ref('tag_syndications_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/tags_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/tags_base.sql
@@ -30,7 +30,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_tags_hashid
 from {{ ref('tags_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/targets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/targets_base.sql
@@ -34,7 +34,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_targets_hashid
 from {{ ref('targets_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ticket_receipts_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ticket_receipts_base.sql
@@ -48,7 +48,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_ticket_receipts_hashid
 from {{ ref('ticket_receipts_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/ticketed_events_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/ticketed_events_base.sql
@@ -85,7 +85,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_ticketed_events_hashid
 from {{ ref('ticketed_events_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/tickets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/tickets_base.sql
@@ -31,7 +31,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_tickets_hashid
 from {{ ref('tickets_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/triggers_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/triggers_base.sql
@@ -35,7 +35,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_triggers_hashid
 from {{ ref('triggers_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/unsubscriptions_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/unsubscriptions_base.sql
@@ -37,7 +37,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_unsubscriptions_hashid
 from {{ ref('unsubscriptions_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_files_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_files_base.sql
@@ -37,7 +37,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_files_hashid
 from {{ ref('user_files_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_ladder_statuses_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_ladder_statuses_base.sql
@@ -30,7 +30,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_ladder_statuses_hashid
 from {{ ref('user_ladder_statuses_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_1_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_1_base.sql
@@ -30,7 +30,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_merge_logs_1_hashid
 from {{ ref('user_merge_logs_1_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_merge_logs_base.sql
@@ -30,7 +30,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_merge_logs_hashid
 from {{ ref('user_merge_logs_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_source_codes_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_source_codes_base.sql
@@ -29,7 +29,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_source_codes_hashid
 from {{ ref('user_source_codes_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_tags_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_tags_base.sql
@@ -28,7 +28,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_tags_hashid
 from {{ ref('user_tags_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/user_tickets_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/user_tickets_base.sql
@@ -29,7 +29,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_user_tickets_hashid
 from {{ ref('user_tickets_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/users_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/users_base.sql
@@ -64,7 +64,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_users_hashid
 from {{ ref('users_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/webhook_messages_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/webhook_messages_base.sql
@@ -32,7 +32,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_webhook_messages_hashid
 from {{ ref('webhook_messages_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}

--- a/dbt-cta/action_network/models/1_cta_full_refresh/webhooks_base.sql
+++ b/dbt-cta/action_network/models/1_cta_full_refresh/webhooks_base.sql
@@ -28,7 +28,3 @@ select
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_webhooks_hashid
 from {{ ref('webhooks_ab4') }}
-
-{% if is_incremental() %}
-where timestamp_trunc(_airbyte_extracted_at, day) in ({{ partitions_to_replace | join(",") }})
-{% endif %}


### PR DESCRIPTION
Now that Airbyte updates the raw data incrementally, we don't want to include these WHERE clauses or else dbt is going to only sync new data (we want ALL the data)