### PR TITLE
hotfix: yeet unnecesary columns to create cta_hashid

### DIFF
--- a/dbt-cta/hustle/models/0_ctes/tags_cte1.sql
+++ b/dbt-cta/hustle/models/0_ctes/tags_cte1.sql
@@ -12,12 +12,9 @@ SELECT
     CAST(`updated_at` AS TIMESTAMP) AS `updated_at`,
     TO_HEX(MD5(CONCAT(
                       `id`,
-                      `agent_visibility`,
-                      `organization_id`,
                       `tag`,
                       `created_at`,
-                      `updated_at`,
-                      `deleted_at`))) AS _cta_hashid,
+                      `updated_at`))) AS _cta_hashid,
     CURRENT_TIMESTAMP() as _cta_sync_datetime_utc
 FROM {{ source('cta', '_tags_raw') }}
     


### PR DESCRIPTION
The dbt was failing to create a `_cta_hashid` because there were optional fields included. This PR pares down the amount of columns that are used to create the `_cta_hashid` so it more faithfully will be created. This was tested locally and the test that was previously failing now passes.