### PR TITLE
hotfix (blocks_incremental): bring back vr_zips_lookup_base

### DIFF
--- a/dbt-cta/blocks_incremental/models/1_cta_incremental/vr_zips_lookup_base.sql
+++ b/dbt-cta/blocks_incremental/models/1_cta_incremental/vr_zips_lookup_base.sql
@@ -1,0 +1,10 @@
+{{ config(
+    cluster_by = "_airbyte_extracted_at",
+    partition_by = {"field": "_airbyte_extracted_at", "data_type": "timestamp", "granularity": "day"},
+    unique_key = "_airbyte_vr_zips_lookup_hashid"
+) }}
+
+-- Final base SQL model
+-- depends_on: {{ ref('votes_ab2') }}
+select * except (_airbyte_raw_id)
+from {{ ref('vr_zips_lookup_ab2') }}


### PR DESCRIPTION
Our `blocks_incremental` dbt still contains CTEs and partner delivery models for `vr_zips_lookup`, but the `_base` model went missing. This hotfix adds the model back. I already made sure this runs successfully locally.