### PR TITLE
feat: take out extra columns from dbt tables

### DIFF
--- a/dbt-cta/openfield/models/0_ctes/knock_conversation_code_cte1.sql
+++ b/dbt-cta/openfield/models/0_ctes/knock_conversation_code_cte1.sql
@@ -32,8 +32,6 @@ select
     cast(universal_source_code as {{ dbt_utils.type_string() }}) as universal_source_code,
     cast(starting_location_id as {{ dbt_utils.type_bigint() }}) as starting_location_id,
     cast(skip_people_search as bool) as skip_people_search,
-    cast(turf_cutter_celery_task_id as {{ dbt_utils.type_string() }}) as turf_cutter_celery_task_id,
-    cast(turf_cutter_status as {{ dbt_utils.type_string() }}) as turf_cutter_status,
 
     -- new fields
     {{ dbt_utils.surrogate_key([
@@ -60,9 +58,7 @@ select
         'action_url',
         'universal_source_code',
         'starting_location_id',
-        'skip_people_search',
-        'turf_cutter_celery_task_id',
-        'turf_cutter_status',
+        'skip_people_search'
     ]) }} as _knock_conversation_code_hashid,
     {{ current_timestamp() }} as _cta_loaded_at
 from {{ source('cta', '_raw_knock_conversation_code') }}

--- a/dbt-cta/openfield/models/0_ctes/redshift_people_celloptins_conversations_cte1.sql
+++ b/dbt-cta/openfield/models/0_ctes/redshift_people_celloptins_conversations_cte1.sql
@@ -39,7 +39,6 @@ select
     cast(question_id as {{ dbt_utils.type_bigint() }}) as question_id,
     cast(question_text as {{ dbt_utils.type_string() }}) as question_text,
     cast(response as {{ dbt_utils.type_string() }}) as response,
-    cast(phone_opt_in as {{ dbt_utils.type_string() }}) as phone_opt_in,
 
     -- new fields
     {{ dbt_utils.surrogate_key([
@@ -73,8 +72,7 @@ select
         'conversation_code_id',
         'question_id',
         'question_text',
-        'response',
-        'phone_opt_in'
+        'response'
     ]) }} as _redshift_people_celloptins_conversations_hashid,
     {{ current_timestamp() }} as _cta_loaded_at
 from {{ source('cta', '_raw_redshift_people_celloptins_conversations') }}

--- a/dbt-cta/openfield/models/0_ctes/redshift_people_email_conversations_cte1.sql
+++ b/dbt-cta/openfield/models/0_ctes/redshift_people_email_conversations_cte1.sql
@@ -39,7 +39,6 @@ select
     cast(question_id as {{ dbt_utils.type_bigint() }}) as question_id,
     cast(question_text as {{ dbt_utils.type_string() }}) as question_text,
     cast(response as {{ dbt_utils.type_string() }}) as response,
-    cast(email_opt_in as {{ dbt_utils.type_string() }}) as email_opt_in,
 
     -- new fields
     {{ dbt_utils.surrogate_key([
@@ -73,8 +72,7 @@ select
         'conversation_code_id',
         'question_id',
         'question_text',
-        'response',
-        'email_opt_in'
+        'response'
     ]) }} as _redshift_people_email_conversations_hashid,
     {{ current_timestamp() }} as _cta_loaded_at
 from {{ source('cta', '_raw_redshift_people_email_conversations') }}

--- a/dbt-cta/openfield/models/1_cta_full_refresh/knock_conversation_code_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/knock_conversation_code_base.sql
@@ -40,8 +40,6 @@ select
     universal_source_code,
     starting_location_id,
     skip_people_search,
-    turf_cutter_celery_task_id,
-    turf_cutter_status,
     _knock_conversation_code_hashid,
     _cta_loaded_at
 

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_celloptins_conversations_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_celloptins_conversations_base.sql
@@ -47,7 +47,6 @@ select
     question_id,
     question_text,
     response,
-    phone_opt_in,
     _redshift_people_celloptins_conversations_hashid,
     _cta_loaded_at
 from {{ ref('redshift_people_celloptins_conversations_cte2') }}

--- a/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_email_conversations_base.sql
+++ b/dbt-cta/openfield/models/1_cta_full_refresh/redshift_people_email_conversations_base.sql
@@ -47,7 +47,6 @@ select
     question_id,
     question_text,
     response,
-    email_opt_in,
     _redshift_people_email_conversations_hashid,
     _cta_loaded_at
 from {{ ref('redshift_people_email_conversations_cte2') }}


### PR DESCRIPTION
There were extra columns that were preventing the new additional openfield partners from being great. By yeeting these dbt columns, all tables were able to be created (when running dbt pipes locally).

Once this PR is merged and tested in dev, [this PR](https://github.com/community-tech-alliance/airflow-dags/pull/809/) will be able to be merged into prod!