### PR TITLE
feat: change to cta_materialized_views

### DIFF
--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -46,7 +46,7 @@ models:
     2_partner_matviews: # for delivery via materialized views
       +tags: 
         - partner
-      +materialized: materialized_view
+      +materialized: cta_materialized_view
       +auto_refresh: false
       +refresh_interval_minutes: 1440
       +grant_access_to:

--- a/dbt-cta/packages.yml
+++ b/dbt-cta/packages.yml
@@ -2,7 +2,7 @@
 
 packages:
   - git: "https://github.com/community-tech-alliance/dbt-materialized-views.git"
-    revision: 1.0.1
+    revision: 2.0.0
   - git: "https://github.com/calogica/dbt-expectations.git"
     revision: 0.8.2
   - git: "https://github.com/dbt-labs/dbt-codegen.git"


### PR DESCRIPTION
[dbt-core 1.6](https://f9ebbc83f6f3414381d6fa9a52957253-dot-us-central1.composer.googleusercontent.com/dags/actblue/grid) added the `materialized view` materialization type. This means that when using dbt 1.6 and higher, the official dbt packages are used for `materialized view` materialization. The problem with the official package is that it doesn't have the ability to add view authorization and gets a bit scuffed in our dev enviroment (idk whats different in there than in prod but the official `materialized view` doesnt even run 🙃 )

This PR changes the default materialization for out matview to the new `cta_materialized_view` from this PR - https://github.com/community-tech-alliance/dbt-materialized-views/pull/1

Note on this, in order to apply these changes:

- [ ] We have to run `dbt-deps` and copy the new generated package for `dbt-materialized-views` into GCS.
- [x] Once thats done, we have to update the `dbt_project.yml` file so that we use the `cta_materialized_view` materialization instead of `materialized_view` in our [2_partner_matviews](https://github.com/community-tech-alliance/dbt-cta/blob/main/dbt-cta/dbt_project.yml#L49) config. (Thats this PR!)


I've deployed this to our dev environment and have run some tests on the [actblue dag ](https://f9ebbc83f6f3414381d6fa9a52957253-dot-us-central1.composer.googleusercontent.com/dags/actblue/grid)

- [Normal Run (refresh matview)](https://f9ebbc83f6f3414381d6fa9a52957253-dot-us-central1.composer.googleusercontent.com/dags/actblue/grid?dag_run_id=scheduled__2024-08-04T21%3A45%3A00%2B00%3A00&task_id=actblue_0_partner_a.dbt_tasks.dbt_actblue.dbt_run_partner&tab=logs)
- [Full-Refresh Run (Create matview and authorize)](https://f9ebbc83f6f3414381d6fa9a52957253-dot-us-central1.composer.googleusercontent.com/dags/actblue/grid?dag_run_id=manual__2024-08-05T21%3A09%3A06%2B00%3A00&task_id=actblue_0_partner_a.dbt_tasks.dbt_actblue.dbt_run_partner)