### PR TITLE
echo19: use existing primary keys instead of hashid for deduping

### DIFF
--- a/dbt-cta/echo19/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/echo19/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -2,11 +2,42 @@ version: 2
 
 models:
 
+  - name: clicks_base
+    description: ''
+    columns:
+      - name: clickId
+        description: ''
+        tests:
+          - unique
+          - not_null
+      - name: clicks_hashid
+        description: ''
+        tests:
+          - unique
+          - not_null
+
+  - name: ivr_contact_base
+    description: ''
+    columns:
+      - name: ivrResultId
+        description: ''
+        tests:
+          - unique
+          - not_null
+      - name: ivr_contact_hashid
+        description: ''
+        tests:
+          - unique
+          - not_null
+
   - name: text_contact_base
     description: ''
     columns:
       - name: textresultid
         description: ''
+        tests:
+          - unique
+          - not_null
       - name: scheduleid
         description: ''
       - name: programid
@@ -124,6 +155,9 @@ models:
     columns:
       - name: answerid
         description: ''
+        tests:
+          - unique
+          - not_null
       - name: contactid
         description: ''
       - name: scheduleid
@@ -151,6 +185,9 @@ models:
     columns:
       - name: tagresultid
         description: ''
+        tests:
+          - unique
+          - not_null
       - name: tagid
         description: ''
       - name: scheduleid

--- a/dbt-cta/echo19/models/1_cta_incremental/clicks_base.sql
+++ b/dbt-cta/echo19/models/1_cta_incremental/clicks_base.sql
@@ -1,5 +1,5 @@
 {{ config(
-    unique_key = "clicks_hashid"
+    unique_key = "clickId"
 ) }}
 
 -- Final base SQL model

--- a/dbt-cta/echo19/models/1_cta_incremental/ivr_contact_base.sql
+++ b/dbt-cta/echo19/models/1_cta_incremental/ivr_contact_base.sql
@@ -1,5 +1,5 @@
 {{ config(
-    unique_key = "ivr_contact_hashid"
+    unique_key = "ivrResultId"
 ) }}
 
 -- Final base SQL model

--- a/dbt-cta/echo19/models/1_cta_incremental/survey_result_base.sql
+++ b/dbt-cta/echo19/models/1_cta_incremental/survey_result_base.sql
@@ -1,5 +1,5 @@
 {{ config(
-    unique_key = "survey_result_hashid"
+    unique_key = "answerId"
 ) }}
 
 -- Final base SQL model

--- a/dbt-cta/echo19/models/1_cta_incremental/tag_result_base.sql
+++ b/dbt-cta/echo19/models/1_cta_incremental/tag_result_base.sql
@@ -1,5 +1,5 @@
 {{ config(
-    unique_key = "tag_result_hashid"
+    unique_key = "tagResultId"
 ) }}
 
 -- Final base SQL model

--- a/dbt-cta/echo19/models/1_cta_incremental/text_contact_base.sql
+++ b/dbt-cta/echo19/models/1_cta_incremental/text_contact_base.sql
@@ -1,5 +1,5 @@
 {{ config(
-    unique_key = "text_contact_hashid"
+    unique_key = "textResultId"
 ) }}
 
 -- Final base SQL model


### PR DESCRIPTION
When checking for dupes in echo19 data, I found that the tables all have existing primary keys. We should use these as unique_key instead of hashids.

Also, the tests were missing a few tables, so I added tests for them and included uniqueness tests for the PKs in all tables.

(We don't have any dupes in this sync right now, everything is fine, but we should definitely at least add the tests in.)