### PR TITLE
sprout social should use existing primary keys for unique_key (+tests)

### DIFF
--- a/dbt-cta/sprout_social/models/0_ctes/client_metadata_ab2.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/client_metadata_ab2.sql
@@ -5,7 +5,7 @@ select * except (rownum) from
     (
         select
             *,
-            row_number() over (partition by _airbyte_client_metadata_hashid order by _airbyte_extracted_at desc) as rownum
+            row_number() over (partition by customer_id order by _airbyte_extracted_at desc) as rownum
         from {{ ref('client_metadata_ab1') }}
     )
 where rownum = 1

--- a/dbt-cta/sprout_social/models/0_ctes/customer_groups_ab2.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/customer_groups_ab2.sql
@@ -5,7 +5,7 @@ select * except (rownum) from
     (
         select
             *,
-            row_number() over (partition by _airbyte_customer_groups_hashid order by _airbyte_extracted_at desc) as rownum
+            row_number() over (partition by group_id order by _airbyte_extracted_at desc) as rownum
         from {{ ref('customer_groups_ab1') }}
     )
 where rownum = 1

--- a/dbt-cta/sprout_social/models/0_ctes/customer_profiles_ab2.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/customer_profiles_ab2.sql
@@ -5,7 +5,7 @@ select * except (rownum) from
     (
         select
             *,
-            row_number() over (partition by _airbyte_customer_profiles_hashid order by _airbyte_extracted_at desc) as rownum
+            row_number() over (partition by customer_profile_id order by _airbyte_extracted_at desc) as rownum
         from {{ ref('customer_profiles_ab1') }}
     )
 where rownum = 1

--- a/dbt-cta/sprout_social/models/0_ctes/customer_tags_ab2.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/customer_tags_ab2.sql
@@ -5,7 +5,7 @@ select * except (rownum) from
     (
         select
             *,
-            row_number() over (partition by _airbyte_customer_tags_hashid order by _airbyte_extracted_at desc) as rownum
+            row_number() over (partition by tag_id order by _airbyte_extracted_at desc) as rownum
         from {{ ref('customer_tags_ab1') }}
     )
 where rownum = 1

--- a/dbt-cta/sprout_social/models/0_ctes/customer_users_ab2.sql
+++ b/dbt-cta/sprout_social/models/0_ctes/customer_users_ab2.sql
@@ -5,7 +5,7 @@ select * except (rownum) from
     (
         select
             *,
-            row_number() over (partition by _airbyte_customer_users_hashid order by _airbyte_extracted_at desc) as rownum
+            row_number() over (partition by id order by _airbyte_extracted_at desc) as rownum
         from {{ ref('customer_users_ab1') }}
     )
 where rownum = 1

--- a/dbt-cta/sprout_social/models/1_cta_incremental/_1_cta_incremental__models.yml
+++ b/dbt-cta/sprout_social/models/1_cta_incremental/_1_cta_incremental__models.yml
@@ -11,6 +11,9 @@ models:
         description: ''
       - name: customer_id
         description: ''
+        tests:
+          - unique
+          - not_null
       - name: _airbyte_client_metadata_hashid
         description: ''
         tests:
@@ -28,6 +31,9 @@ models:
         description: ''
       - name: customer_profile_id
         description: ''
+        tests:
+          - unique
+          - not_null
       - name: reporting_period_day
         description: ''
       - name: metrics
@@ -221,6 +227,9 @@ models:
         description: ''
       - name: customer_profile_id
         description: ''
+        tests:
+          - unique
+          - not_null
       - name: reporting_period_day
         description: ''
       - name: metrics
@@ -582,6 +591,9 @@ models:
         description: ''
       - name: id
         description: ''
+        tests:
+          - unique
+          - not_null
       - name: _airbyte_customer_users_hashid
         description: ''
         tests:
@@ -605,6 +617,9 @@ models:
         description: ''
       - name: customer_profile_id
         description: ''
+        tests:
+          - unique
+          - not_null
       - name: network_type
         description: ''
       - name: native_name
@@ -679,6 +694,9 @@ models:
         description: ''
       - name: tag_id
         description: ''
+        tests:
+          - unique
+          - not_null
       - name: text
         description: ''
       - name: type
@@ -698,6 +716,9 @@ models:
         description: ''
       - name: group_id
         description: ''
+        tests:
+          - unique
+          - not_null
       - name: name
         description: ''
       - name: _airbyte_customer_groups_hashid

--- a/dbt-cta/sprout_social/models/1_cta_incremental/client_metadata_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_incremental/client_metadata_base.sql
@@ -1,7 +1,7 @@
 {{ config(
     cluster_by = "_airbyte_extracted_at",
     partition_by = {"field": "_airbyte_extracted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = "_airbyte_client_metadata_hashid"
+    unique_key = "customer_id"
 ) }}
 
 -- Final base SQL model

--- a/dbt-cta/sprout_social/models/1_cta_incremental/customer_groups_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_incremental/customer_groups_base.sql
@@ -1,7 +1,7 @@
 {{ config(
     cluster_by = "_airbyte_extracted_at",
     partition_by = {"field": "_airbyte_extracted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = "_airbyte_customer_groups_hashid"
+    unique_key = "group_id"
 ) }}
 
 -- Final base SQL model

--- a/dbt-cta/sprout_social/models/1_cta_incremental/customer_profiles_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_incremental/customer_profiles_base.sql
@@ -1,7 +1,7 @@
 {{ config(
     cluster_by = "_airbyte_extracted_at",
     partition_by = {"field": "_airbyte_extracted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = "_airbyte_customer_profiles_hashid"
+    unique_key = "customer_profile_id"
 ) }}
 
 -- Final base SQL model

--- a/dbt-cta/sprout_social/models/1_cta_incremental/customer_tags_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_incremental/customer_tags_base.sql
@@ -1,7 +1,7 @@
 {{ config(
     cluster_by = "_airbyte_extracted_at",
     partition_by = {"field": "_airbyte_extracted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = "_airbyte_customer_tags_hashid"
+    unique_key = "tag_id"
 ) }}
 
 -- Final base SQL model

--- a/dbt-cta/sprout_social/models/1_cta_incremental/customer_users_base.sql
+++ b/dbt-cta/sprout_social/models/1_cta_incremental/customer_users_base.sql
@@ -1,7 +1,7 @@
 {{ config(
     cluster_by = "_airbyte_extracted_at",
     partition_by = {"field": "_airbyte_extracted_at", "data_type": "timestamp", "granularity": "day"},
-    unique_key = "_airbyte_customer_users_hashid"
+    unique_key = "id"
 ) }}
 
 -- Final base SQL model


### PR DESCRIPTION
similar to https://github.com/community-tech-alliance/dbt-cta/pull/399 , which did the same thing for echo19.

Some of the Sprout Social tables have existing primary keys that we should use for the unique_key rather than the hashids. This PR also adds non-null and uniqueness tests for those PKs.