### PR TITLE
fix: remove the videos field from fbpages page table

### DIFF
--- a/dbt-cta/facebook_pages/models/1_cta_full_refresh/page_base.sql
+++ b/dbt-cta/facebook_pages/models/1_cta_full_refresh/page_base.sql
@@ -25,7 +25,6 @@ select
     `messaging_feature_status`,
     `subscribed_apps`,
     `about`,
-    `videos`,
     `published_posts`,
     `cover`,
     `culinary_team`,


### PR DESCRIPTION
https://techallies.atlassian.net/browse/PAD-2666

FB Pages sync was failing with the following error
```
'{"error":{"message":"An unknown error has occurred.","type":"OAuthException","code":1,"fbtrace_id":""}}'
```
After removing the `videos` field from the page stream, everything seems good