### PR TITLE
feat: add deduping CTEs to snapchat models

### DIFF
--- a/dbt-cta/snapchat_marketing/models/0_ctes/adaccounts_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adaccounts_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('adaccounts_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adaccounts_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adaccounts_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adaccounts_regulations_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adaccounts_regulations_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by ad_account_id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('adaccounts_regulations_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adaccounts_regulations_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adaccounts_regulations_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/ads_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/ads_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('ads_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/ads_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/ads_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/ads_stats_daily_ab4.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/ads_stats_daily_ab4.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/ads_stats_daily_ab4.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/ads_stats_daily_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by _airbyte_ads_stats_daily_hashid order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('ads_stats_daily_ab3') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('adsquads_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_skadnetwork_properties_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_skadnetwork_properties_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_skadnetwork_properties_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_skadnetwork_properties_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by ad_squad_id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('adsquads_skadnetwork_properties_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_targeting_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_targeting_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by ad_squad_id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('adsquads_targeting_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_targeting_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_targeting_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_targeting_geos_ab4.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_targeting_geos_ab4.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_targeting_geos_ab4.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/adsquads_targeting_geos_ab4.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by _airbyte_geos_hashid order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('adsquads_targeting_geos_ab3') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/campaigns_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/campaigns_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('campaigns_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/campaigns_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/campaigns_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/creatives_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/creatives_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('creatives_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/creatives_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/creatives_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/creatives_web_view_properties_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/creatives_web_view_properties_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by creative_id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('creatives_web_view_properties_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/creatives_web_view_properties_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/creatives_web_view_properties_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/media_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/media_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('media_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/media_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/media_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/organizations_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/organizations_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('organizations_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/organizations_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/organizations_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/organizations_configuration_settings_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/organizations_configuration_settings_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/organizations_configuration_settings_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/organizations_configuration_settings_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by organization_id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('organizations_configuration_settings_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/0_ctes/segments_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/segments_ab3.sql
@@ -1,4 +1,3 @@
--- ensures the base model contains only one row per hashid
 -- this deduplicates data even if the source data contains duplicate rows
 
 select * except (rownum) from

--- a/dbt-cta/snapchat_marketing/models/0_ctes/segments_ab3.sql
+++ b/dbt-cta/snapchat_marketing/models/0_ctes/segments_ab3.sql
@@ -1,0 +1,11 @@
+-- ensures the base model contains only one row per hashid
+-- this deduplicates data even if the source data contains duplicate rows
+
+select * except (rownum) from
+    (
+        select
+            *,
+            row_number() over (partition by id order by _airbyte_extracted_at desc) as rownum
+        from {{ ref('segments_ab2') }}
+    )
+where rownum = 1

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/ad_stats_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/ad_stats_base.sql
@@ -4,7 +4,7 @@
     unique_key = '_airbyte_ads_stats_daily_hashid'
 ) }}
 
--- depends_on: {{ ref('ads_stats_daily_ab3') }}
+-- depends_on: {{ ref('ads_stats_daily_ab4') }}
 select
     id,
     type,
@@ -83,4 +83,4 @@ select
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at,
     _airbyte_ads_stats_daily_hashid
-from {{ ref('ads_stats_daily_ab3') }}
+from {{ ref('ads_stats_daily_ab4') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/adaccounts_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/adaccounts_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'id'
 ) }}
 
--- depends_on: {{ ref('adaccounts_ab2') }}
+-- depends_on: {{ ref('adaccounts_ab3') }}
 select
     id,
     name,
@@ -25,4 +25,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('adaccounts_ab2') }}
+from {{ ref('adaccounts_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/adaccounts_regulations_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/adaccounts_regulations_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'ad_account_id'
 ) }}
 
--- depends_on: {{ ref('adaccounts_base') }}, {{ ref('adaccounts_regulations_ab2') }}
+-- depends_on: {{ ref('adaccounts_base') }}, {{ ref('adaccounts_regulations_ab3') }}
 select
     ad_account_id,
     restricted_delivery_signals,
@@ -12,4 +12,4 @@ select
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
     
-from {{ ref('adaccounts_regulations_ab2') }}
+from {{ ref('adaccounts_regulations_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/ads_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/ads_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'id'
 ) }}
 
--- depends_on: {{ ref('ads_ab2') }}
+-- depends_on: {{ ref('ads_ab3') }}
 select
     id,
     name,
@@ -20,4 +20,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('ads_ab2') }}
+from {{ ref('ads_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/adsquads_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/adsquads_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'id'
 ) }}
 
--- depends_on: {{ ref('adsquads_ab2') }}
+-- depends_on: {{ ref('adsquads_ab3') }}
 select
     id,
     name,
@@ -35,4 +35,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('adsquads_ab2') }}
+from {{ ref('adsquads_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/adsquads_skadnetwork_properties_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/adsquads_skadnetwork_properties_base.sql
@@ -4,12 +4,12 @@
     unique_key = 'ad_squad_id'
 ) }}
 
--- depends_on: {{ ref('adsquads_skadnetwork_properties_ab2') }}
+-- depends_on: {{ ref('adsquads_skadnetwork_properties_ab3') }}
 select
     ad_squad_id,
     status,
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('adsquads_skadnetwork_properties_ab2') }}
+from {{ ref('adsquads_skadnetwork_properties_ab3') }}
 -- skadnetwork_properties at adsquads_base/skadnetwork_properties from {{ ref('adsquads_base') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/adsquads_targeting_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/adsquads_targeting_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'ad_squad_id'
 ) }}
 
--- depends_on: {{ ref('adsquads_targeting_ab2') }}
+-- depends_on: {{ ref('adsquads_targeting_ab3') }}
 select
     ad_squad_id,
     geos,
@@ -13,4 +13,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('adsquads_targeting_ab2') }}
+from {{ ref('adsquads_targeting_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/adsquads_targeting_geos_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/adsquads_targeting_geos_base.sql
@@ -4,7 +4,7 @@
     unique_key = '_airbyte_geos_hashid'
 ) }}
 
--- depends_on: {{ ref('adsquads_targeting_geos_ab3') }}
+-- depends_on: {{ ref('adsquads_targeting_geos_ab4') }}
 select
     _airbyte_geos_hashid,
     ad_squad_id,
@@ -19,4 +19,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('adsquads_targeting_geos_ab3') }}
+from {{ ref('adsquads_targeting_geos_ab4') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/campaigns_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/campaigns_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'id'
 ) }}
 
--- depends_on: {{ ref('campaigns_ab2') }}
+-- depends_on: {{ ref('campaigns_ab3') }}
 select
     id,
     name,
@@ -19,4 +19,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('campaigns_ab2') }}
+from {{ ref('campaigns_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/creatives_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/creatives_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'id'
 ) }}
 
--- depends_on: {{ ref('creatives_ab2') }}
+-- depends_on: {{ ref('creatives_ab3') }}
 select
     id,
     name,
@@ -33,4 +33,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('creatives_ab2') }}
+from {{ ref('creatives_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/creatives_web_view_properties_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/creatives_web_view_properties_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'creative_id'
 ) }}
 
--- depends_on: {{ ref('creatives_web_view_properties_ab2') }}
+-- depends_on: {{ ref('creatives_web_view_properties_ab3') }}
 select
     creative_id,
     url,
@@ -20,4 +20,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('creatives_web_view_properties_ab2') }}
+from {{ ref('creatives_web_view_properties_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/media_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/media_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'id'
 ) }}
 
--- depends_on: {{ ref('media_ab2') }}
+-- depends_on: {{ ref('media_ab3') }}
 select
     id,
     {{ adapter.quote('hash') }},
@@ -25,4 +25,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('media_ab2') }}
+from {{ ref('media_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/organizations_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/organizations_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'id'
 ) }}
 
--- depends_on: {{ ref('organizations_ab2') }}
+-- depends_on: {{ ref('organizations_ab3') }}
 select
     id,
     name,
@@ -31,4 +31,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('organizations_ab2') }}
+from {{ ref('organizations_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/organizations_configuration_settings_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/organizations_configuration_settings_base.sql
@@ -5,11 +5,11 @@
 
 ) }}
 
--- depends_on: {{ ref('organizations_configuration_settings_ab2') }}
+-- depends_on: {{ ref('organizations_configuration_settings_ab3') }}
 select
     organization_id,
     notifications_enabled,
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('organizations_configuration_settings_ab2') }}
+from {{ ref('organizations_configuration_settings_ab3') }}

--- a/dbt-cta/snapchat_marketing/models/1_cta_incremental/segments_base.sql
+++ b/dbt-cta/snapchat_marketing/models/1_cta_incremental/segments_base.sql
@@ -4,7 +4,7 @@
     unique_key = 'id'
 ) }}
 
--- depends_on: {{ ref('segments_ab2') }}
+-- depends_on: {{ ref('segments_ab3') }}
 select
     id,
     name,
@@ -23,4 +23,4 @@ select
     _airbyte_raw_id,
     _airbyte_extracted_at,
     {{ current_timestamp() }} as _airbyte_normalized_at
-from {{ ref('segments_ab2') }}
+from {{ ref('segments_ab3') }}


### PR DESCRIPTION
Snapchat is one of our older syncs, so we hadn't yet gotten around to adding these CTEs to dedupe when there are dupe rows in the raw data (which recently has been the case for `segments`).

Ran this locally, seems fine ✅ 