### PR TITLE
feat: using jinja templater instead of dbt

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,9 +1,10 @@
 [sqlfluff]
-templater = dbt
+templater = jinja
 dialect = bigquery
 nocolor = True
 max_line_length = 0
 exclude_rules = CP02, RF04
+ignore = templating
 
 [sqlfluff:templater:dbt]
 project_dir = dbt-cta/


### PR DESCRIPTION
For linting purposes, we can use jinja (instead of dbt) as the templater and tell it to ignore templating since we don't need sqlfluff to actually validate the queries and attempt to connect to the database (which is does by default with dbt). 

Using jinja is more lightweight and still does the lint formatting that we want sqlfluff to do for us!

I haven't been able to find any discrepancies between using dbt and jinja as the templator for our sql files in my testing.