### PR TITLE
meh: remove the full-refresh flag from dbt-project

### DIFF
--- a/dbt-cta/dbt_project.yml
+++ b/dbt-cta/dbt_project.yml
@@ -32,7 +32,6 @@ models:
       +materialized: incremental
       +incremental_strategy: insert_overwrite
       +on_schema_change: sync_all_columns
-      +full_refresh: false
     1_cta_incremental:
       +tags:
         - cta


### PR DESCRIPTION
Having `+full_refresh: false` set in the dbt_project.yml file means we cant pass in full-refresh through the CLI when running. Since we do need to run full-refresh sometimes, I am removing it from the `1_cta_full_refresh` config.